### PR TITLE
Updates for QEMU

### DIFF
--- a/la-fp-d.txt
+++ b/la-fp-d.txt
@@ -17,9 +17,9 @@
 01146800 frsqrt.d               FdFj
 01147800 frecipe.d              FdFj            @rev=1p10
 01148800 frsqrte.d              FdFj            @rev=1p10
-01149800 fmov.d                 FdFj
-0114a800 movgr2fr.d             FdJ
-0114b800 movfr2gr.d             DFj
+01149800 fmov.d                 FdFj            @qemu
+0114a800 movgr2fr.d             FdJ             @qemu
+0114b800 movfr2gr.d             DFj             @qemu
 01191800 fcvt.s.d               FdFj
 01192400 fcvt.d.s               FdFj
 011a0800 ftintrm.w.d            FdFj
@@ -61,7 +61,7 @@
 0c2a8000 fcmp.sor.d             CdFjFk
 0c2c0000 fcmp.cune.d            CdFjFk
 0c2c8000 fcmp.sune.d            CdFjFk
-2b800000 fld.d                  FdJSk12
-2bc00000 fst.d                  FdJSk12
-38340000 fldx.d                 FdJK
-383c0000 fstx.d                 FdJK
+2b800000 fld.d                  FdJSk12         @qemu
+2bc00000 fst.d                  FdJSk12         @qemu
+38340000 fldx.d                 FdJK            @qemu
+383c0000 fstx.d                 FdJK            @qemu

--- a/la-fp-s.txt
+++ b/la-fp-s.txt
@@ -61,7 +61,7 @@
 0c1a8000 fcmp.sor.s             CdFjFk
 0c1c0000 fcmp.cune.s            CdFjFk
 0c1c8000 fcmp.sune.s            CdFjFk
-2b000000 fld.s                  FdJSk12
-2b400000 fst.s                  FdJSk12
-38300000 fldx.s                 FdJK
-38380000 fstx.s                 FdJK
+2b000000 fld.s                  FdJSk12         @qemu
+2b400000 fst.s                  FdJSk12         @qemu
+38300000 fldx.s                 FdJK            @qemu
+38380000 fstx.s                 FdJK            @qemu

--- a/lasx.txt
+++ b/lasx.txt
@@ -50,48 +50,48 @@
 0caa8000 xvfcmp.sor.d           XdXjXk
 0cac0000 xvfcmp.cune.d          XdXjXk
 0cac8000 xvfcmp.sune.d          XdXjXk
-0d200000 xvbitsel.v             XdXjXkXa
-0d600000 xvshuf.b               XdXjXkXa
-2c800000 xvld                   XdJSk12
-2cc00000 xvst                   XdJSk12
-32100000 xvldrepl.d             XdJSk9          @orig_fmt=XdJSk9ps3
-32200000 xvldrepl.w             XdJSk10         @orig_fmt=XdJSk10ps2
-32400000 xvldrepl.h             XdJSk11         @orig_fmt=XdJSk11ps1
-32800000 xvldrepl.b             XdJSk12
-33100000 xvstelm.d              XdJSk8Un2       @orig_fmt=XdJSk8ps3Un2
-33200000 xvstelm.w              XdJSk8Un3       @orig_fmt=XdJSk8ps2Un3
-33400000 xvstelm.h              XdJSk8Un4       @orig_fmt=XdJSk8ps1Un4
-33800000 xvstelm.b              XdJSk8Un5
-38480000 xvldx                  XdJK
-384c0000 xvstx                  XdJK
-74000000 xvseq.b                XdXjXk
-74008000 xvseq.h                XdXjXk
-74010000 xvseq.w                XdXjXk
-74018000 xvseq.d                XdXjXk
-74020000 xvsle.b                XdXjXk
-74028000 xvsle.h                XdXjXk
-74030000 xvsle.w                XdXjXk
-74038000 xvsle.d                XdXjXk
-74040000 xvsle.bu               XdXjXk
-74048000 xvsle.hu               XdXjXk
-74050000 xvsle.wu               XdXjXk
-74058000 xvsle.du               XdXjXk
-74060000 xvslt.b                XdXjXk
-74068000 xvslt.h                XdXjXk
-74070000 xvslt.w                XdXjXk
-74078000 xvslt.d                XdXjXk
-74080000 xvslt.bu               XdXjXk
-74088000 xvslt.hu               XdXjXk
-74090000 xvslt.wu               XdXjXk
-74098000 xvslt.du               XdXjXk
-740a0000 xvadd.b                XdXjXk
-740a8000 xvadd.h                XdXjXk
-740b0000 xvadd.w                XdXjXk
-740b8000 xvadd.d                XdXjXk
-740c0000 xvsub.b                XdXjXk
-740c8000 xvsub.h                XdXjXk
-740d0000 xvsub.w                XdXjXk
-740d8000 xvsub.d                XdXjXk
+0d200000 xvbitsel.v             XdXjXkXa        @qemu
+0d600000 xvshuf.b               XdXjXkXa        @qemu
+2c800000 xvld                   XdJSk12         @qemu
+2cc00000 xvst                   XdJSk12         @qemu
+32100000 xvldrepl.d             XdJSk9          @orig_fmt=XdJSk9ps3 @qemu
+32200000 xvldrepl.w             XdJSk10         @orig_fmt=XdJSk10ps2 @qemu
+32400000 xvldrepl.h             XdJSk11         @orig_fmt=XdJSk11ps1 @qemu
+32800000 xvldrepl.b             XdJSk12         @qemu
+33100000 xvstelm.d              XdJSk8Un2       @orig_fmt=XdJSk8ps3Un2 @qemu
+33200000 xvstelm.w              XdJSk8Un3       @orig_fmt=XdJSk8ps2Un3 @qemu
+33400000 xvstelm.h              XdJSk8Un4       @orig_fmt=XdJSk8ps1Un4 @qemu
+33800000 xvstelm.b              XdJSk8Un5       @qemu
+38480000 xvldx                  XdJK            @qemu
+384c0000 xvstx                  XdJK            @qemu
+74000000 xvseq.b                XdXjXk          @qemu
+74008000 xvseq.h                XdXjXk          @qemu
+74010000 xvseq.w                XdXjXk          @qemu
+74018000 xvseq.d                XdXjXk          @qemu
+74020000 xvsle.b                XdXjXk          @qemu
+74028000 xvsle.h                XdXjXk          @qemu
+74030000 xvsle.w                XdXjXk          @qemu
+74038000 xvsle.d                XdXjXk          @qemu
+74040000 xvsle.bu               XdXjXk          @qemu
+74048000 xvsle.hu               XdXjXk          @qemu
+74050000 xvsle.wu               XdXjXk          @qemu
+74058000 xvsle.du               XdXjXk          @qemu
+74060000 xvslt.b                XdXjXk          @qemu
+74068000 xvslt.h                XdXjXk          @qemu
+74070000 xvslt.w                XdXjXk          @qemu
+74078000 xvslt.d                XdXjXk          @qemu
+74080000 xvslt.bu               XdXjXk          @qemu
+74088000 xvslt.hu               XdXjXk          @qemu
+74090000 xvslt.wu               XdXjXk          @qemu
+74098000 xvslt.du               XdXjXk          @qemu
+740a0000 xvadd.b                XdXjXk          @qemu
+740a8000 xvadd.h                XdXjXk          @qemu
+740b0000 xvadd.w                XdXjXk          @qemu
+740b8000 xvadd.d                XdXjXk          @qemu
+740c0000 xvsub.b                XdXjXk          @qemu
+740c8000 xvsub.h                XdXjXk          @qemu
+740d0000 xvsub.w                XdXjXk          @qemu
+740d8000 xvsub.d                XdXjXk          @qemu
 741e0000 xvaddwev.h.b           XdXjXk
 741e8000 xvaddwev.w.h           XdXjXk
 741f0000 xvaddwev.d.w           XdXjXk
@@ -132,22 +132,22 @@
 74408000 xvaddwod.w.hu.h        XdXjXk
 74410000 xvaddwod.d.wu.w        XdXjXk
 74418000 xvaddwod.q.du.d        XdXjXk
-74460000 xvsadd.b               XdXjXk
-74468000 xvsadd.h               XdXjXk
-74470000 xvsadd.w               XdXjXk
-74478000 xvsadd.d               XdXjXk
-74480000 xvssub.b               XdXjXk
-74488000 xvssub.h               XdXjXk
-74490000 xvssub.w               XdXjXk
-74498000 xvssub.d               XdXjXk
-744a0000 xvsadd.bu              XdXjXk
-744a8000 xvsadd.hu              XdXjXk
-744b0000 xvsadd.wu              XdXjXk
-744b8000 xvsadd.du              XdXjXk
-744c0000 xvssub.bu              XdXjXk
-744c8000 xvssub.hu              XdXjXk
-744d0000 xvssub.wu              XdXjXk
-744d8000 xvssub.du              XdXjXk
+74460000 xvsadd.b               XdXjXk          @qemu
+74468000 xvsadd.h               XdXjXk          @qemu
+74470000 xvsadd.w               XdXjXk          @qemu
+74478000 xvsadd.d               XdXjXk          @qemu
+74480000 xvssub.b               XdXjXk          @qemu
+74488000 xvssub.h               XdXjXk          @qemu
+74490000 xvssub.w               XdXjXk          @qemu
+74498000 xvssub.d               XdXjXk          @qemu
+744a0000 xvsadd.bu              XdXjXk          @qemu
+744a8000 xvsadd.hu              XdXjXk          @qemu
+744b0000 xvsadd.wu              XdXjXk          @qemu
+744b8000 xvsadd.du              XdXjXk          @qemu
+744c0000 xvssub.bu              XdXjXk          @qemu
+744c8000 xvssub.hu              XdXjXk          @qemu
+744d0000 xvssub.wu              XdXjXk          @qemu
+744d8000 xvssub.du              XdXjXk          @qemu
 74540000 xvhaddw.h.b            XdXjXk
 74548000 xvhaddw.w.h            XdXjXk
 74550000 xvhaddw.d.w            XdXjXk
@@ -192,26 +192,26 @@
 746a8000 xvavgr.hu              XdXjXk
 746b0000 xvavgr.wu              XdXjXk
 746b8000 xvavgr.du              XdXjXk
-74700000 xvmax.b                XdXjXk
-74708000 xvmax.h                XdXjXk
-74710000 xvmax.w                XdXjXk
-74718000 xvmax.d                XdXjXk
-74720000 xvmin.b                XdXjXk
-74728000 xvmin.h                XdXjXk
-74730000 xvmin.w                XdXjXk
-74738000 xvmin.d                XdXjXk
-74740000 xvmax.bu               XdXjXk
-74748000 xvmax.hu               XdXjXk
-74750000 xvmax.wu               XdXjXk
-74758000 xvmax.du               XdXjXk
-74760000 xvmin.bu               XdXjXk
-74768000 xvmin.hu               XdXjXk
-74770000 xvmin.wu               XdXjXk
-74778000 xvmin.du               XdXjXk
-74840000 xvmul.b                XdXjXk
-74848000 xvmul.h                XdXjXk
-74850000 xvmul.w                XdXjXk
-74858000 xvmul.d                XdXjXk
+74700000 xvmax.b                XdXjXk          @qemu
+74708000 xvmax.h                XdXjXk          @qemu
+74710000 xvmax.w                XdXjXk          @qemu
+74718000 xvmax.d                XdXjXk          @qemu
+74720000 xvmin.b                XdXjXk          @qemu
+74728000 xvmin.h                XdXjXk          @qemu
+74730000 xvmin.w                XdXjXk          @qemu
+74738000 xvmin.d                XdXjXk          @qemu
+74740000 xvmax.bu               XdXjXk          @qemu
+74748000 xvmax.hu               XdXjXk          @qemu
+74750000 xvmax.wu               XdXjXk          @qemu
+74758000 xvmax.du               XdXjXk          @qemu
+74760000 xvmin.bu               XdXjXk          @qemu
+74768000 xvmin.hu               XdXjXk          @qemu
+74770000 xvmin.wu               XdXjXk          @qemu
+74778000 xvmin.du               XdXjXk          @qemu
+74840000 xvmul.b                XdXjXk          @qemu
+74848000 xvmul.h                XdXjXk          @qemu
+74850000 xvmul.w                XdXjXk          @qemu
+74858000 xvmul.d                XdXjXk          @qemu
 74860000 xvmuh.b                XdXjXk
 74868000 xvmuh.h                XdXjXk
 74870000 xvmuh.w                XdXjXk
@@ -292,22 +292,22 @@
 74e68000 xvmod.hu               XdXjXk
 74e70000 xvmod.wu               XdXjXk
 74e78000 xvmod.du               XdXjXk
-74e80000 xvsll.b                XdXjXk
-74e88000 xvsll.h                XdXjXk
-74e90000 xvsll.w                XdXjXk
-74e98000 xvsll.d                XdXjXk
-74ea0000 xvsrl.b                XdXjXk
-74ea8000 xvsrl.h                XdXjXk
-74eb0000 xvsrl.w                XdXjXk
-74eb8000 xvsrl.d                XdXjXk
-74ec0000 xvsra.b                XdXjXk
-74ec8000 xvsra.h                XdXjXk
-74ed0000 xvsra.w                XdXjXk
-74ed8000 xvsra.d                XdXjXk
-74ee0000 xvrotr.b               XdXjXk
-74ee8000 xvrotr.h               XdXjXk
-74ef0000 xvrotr.w               XdXjXk
-74ef8000 xvrotr.d               XdXjXk
+74e80000 xvsll.b                XdXjXk          @qemu
+74e88000 xvsll.h                XdXjXk          @qemu
+74e90000 xvsll.w                XdXjXk          @qemu
+74e98000 xvsll.d                XdXjXk          @qemu
+74ea0000 xvsrl.b                XdXjXk          @qemu
+74ea8000 xvsrl.h                XdXjXk          @qemu
+74eb0000 xvsrl.w                XdXjXk          @qemu
+74eb8000 xvsrl.d                XdXjXk          @qemu
+74ec0000 xvsra.b                XdXjXk          @qemu
+74ec8000 xvsra.h                XdXjXk          @qemu
+74ed0000 xvsra.w                XdXjXk          @qemu
+74ed8000 xvsra.d                XdXjXk          @qemu
+74ee0000 xvrotr.b               XdXjXk          @qemu
+74ee8000 xvrotr.h               XdXjXk          @qemu
+74ef0000 xvrotr.w               XdXjXk          @qemu
+74ef8000 xvrotr.d               XdXjXk          @qemu
 74f00000 xvsrlr.b               XdXjXk
 74f08000 xvsrlr.h               XdXjXk
 74f10000 xvsrlr.w               XdXjXk
@@ -388,16 +388,16 @@
 75208000 xvpickod.h             XdXjXk
 75210000 xvpickod.w             XdXjXk
 75218000 xvpickod.d             XdXjXk
-75220000 xvreplve.b             XdXjK
-75228000 xvreplve.h             XdXjK
-75230000 xvreplve.w             XdXjK
-75238000 xvreplve.d             XdXjK
-75260000 xvand.v                XdXjXk
-75268000 xvor.v                 XdXjXk
-75270000 xvxor.v                XdXjXk
-75278000 xvnor.v                XdXjXk
-75280000 xvandn.v               XdXjXk
-75288000 xvorn.v                XdXjXk
+75220000 xvreplve.b             XdXjK           @qemu
+75228000 xvreplve.h             XdXjK           @qemu
+75230000 xvreplve.w             XdXjK           @qemu
+75238000 xvreplve.d             XdXjK           @qemu
+75260000 xvand.v                XdXjXk          @qemu
+75268000 xvor.v                 XdXjXk          @qemu
+75270000 xvxor.v                XdXjXk          @qemu
+75278000 xvnor.v                XdXjXk          @qemu
+75280000 xvandn.v               XdXjXk          @qemu
+75288000 xvorn.v                XdXjXk          @qemu
 752b0000 xvfrstp.b              XdXjXk
 752b8000 xvfrstp.h              XdXjXk
 752d0000 xvadd.q                XdXjXk
@@ -434,52 +434,52 @@
 757b0000 xvshuf.w               XdXjXk
 757b8000 xvshuf.d               XdXjXk
 757d0000 xvperm.w               XdXjXk
-76800000 xvseqi.b               XdXjSk5
-76808000 xvseqi.h               XdXjSk5
-76810000 xvseqi.w               XdXjSk5
-76818000 xvseqi.d               XdXjSk5
-76820000 xvslei.b               XdXjSk5
-76828000 xvslei.h               XdXjSk5
-76830000 xvslei.w               XdXjSk5
-76838000 xvslei.d               XdXjSk5
-76840000 xvslei.bu              XdXjUk5
-76848000 xvslei.hu              XdXjUk5
-76850000 xvslei.wu              XdXjUk5
-76858000 xvslei.du              XdXjUk5
-76860000 xvslti.b               XdXjSk5
-76868000 xvslti.h               XdXjSk5
-76870000 xvslti.w               XdXjSk5
-76878000 xvslti.d               XdXjSk5
-76880000 xvslti.bu              XdXjUk5
-76888000 xvslti.hu              XdXjUk5
-76890000 xvslti.wu              XdXjUk5
-76898000 xvslti.du              XdXjUk5
-768a0000 xvaddi.bu              XdXjUk5
-768a8000 xvaddi.hu              XdXjUk5
-768b0000 xvaddi.wu              XdXjUk5
-768b8000 xvaddi.du              XdXjUk5
-768c0000 xvsubi.bu              XdXjUk5
-768c8000 xvsubi.hu              XdXjUk5
-768d0000 xvsubi.wu              XdXjUk5
-768d8000 xvsubi.du              XdXjUk5
+76800000 xvseqi.b               XdXjSk5         @qemu
+76808000 xvseqi.h               XdXjSk5         @qemu
+76810000 xvseqi.w               XdXjSk5         @qemu
+76818000 xvseqi.d               XdXjSk5         @qemu
+76820000 xvslei.b               XdXjSk5         @qemu
+76828000 xvslei.h               XdXjSk5         @qemu
+76830000 xvslei.w               XdXjSk5         @qemu
+76838000 xvslei.d               XdXjSk5         @qemu
+76840000 xvslei.bu              XdXjUk5         @qemu
+76848000 xvslei.hu              XdXjUk5         @qemu
+76850000 xvslei.wu              XdXjUk5         @qemu
+76858000 xvslei.du              XdXjUk5         @qemu
+76860000 xvslti.b               XdXjSk5         @qemu
+76868000 xvslti.h               XdXjSk5         @qemu
+76870000 xvslti.w               XdXjSk5         @qemu
+76878000 xvslti.d               XdXjSk5         @qemu
+76880000 xvslti.bu              XdXjUk5         @qemu
+76888000 xvslti.hu              XdXjUk5         @qemu
+76890000 xvslti.wu              XdXjUk5         @qemu
+76898000 xvslti.du              XdXjUk5         @qemu
+768a0000 xvaddi.bu              XdXjUk5         @qemu
+768a8000 xvaddi.hu              XdXjUk5         @qemu
+768b0000 xvaddi.wu              XdXjUk5         @qemu
+768b8000 xvaddi.du              XdXjUk5         @qemu
+768c0000 xvsubi.bu              XdXjUk5         @qemu
+768c8000 xvsubi.hu              XdXjUk5         @qemu
+768d0000 xvsubi.wu              XdXjUk5         @qemu
+768d8000 xvsubi.du              XdXjUk5         @qemu
 768e0000 xvbsll.v               XdXjUk5
 768e8000 xvbsrl.v               XdXjUk5
-76900000 xvmaxi.b               XdXjSk5
-76908000 xvmaxi.h               XdXjSk5
-76910000 xvmaxi.w               XdXjSk5
-76918000 xvmaxi.d               XdXjSk5
-76920000 xvmini.b               XdXjSk5
-76928000 xvmini.h               XdXjSk5
-76930000 xvmini.w               XdXjSk5
-76938000 xvmini.d               XdXjSk5
-76940000 xvmaxi.bu              XdXjUk5
-76948000 xvmaxi.hu              XdXjUk5
-76950000 xvmaxi.wu              XdXjUk5
-76958000 xvmaxi.du              XdXjUk5
-76960000 xvmini.bu              XdXjUk5
-76968000 xvmini.hu              XdXjUk5
-76970000 xvmini.wu              XdXjUk5
-76978000 xvmini.du              XdXjUk5
+76900000 xvmaxi.b               XdXjSk5         @qemu
+76908000 xvmaxi.h               XdXjSk5         @qemu
+76910000 xvmaxi.w               XdXjSk5         @qemu
+76918000 xvmaxi.d               XdXjSk5         @qemu
+76920000 xvmini.b               XdXjSk5         @qemu
+76928000 xvmini.h               XdXjSk5         @qemu
+76930000 xvmini.w               XdXjSk5         @qemu
+76938000 xvmini.d               XdXjSk5         @qemu
+76940000 xvmaxi.bu              XdXjUk5         @qemu
+76948000 xvmaxi.hu              XdXjUk5         @qemu
+76950000 xvmaxi.wu              XdXjUk5         @qemu
+76958000 xvmaxi.du              XdXjUk5         @qemu
+76960000 xvmini.bu              XdXjUk5         @qemu
+76968000 xvmini.hu              XdXjUk5         @qemu
+76970000 xvmini.wu              XdXjUk5         @qemu
+76978000 xvmini.du              XdXjUk5         @qemu
 769a0000 xvfrstpi.b             XdXjUk5
 769a8000 xvfrstpi.h             XdXjUk5
 769c0000 xvclo.b                XdXj
@@ -494,10 +494,10 @@
 769c2400 xvpcnt.h               XdXj
 769c2800 xvpcnt.w               XdXj
 769c2c00 xvpcnt.d               XdXj
-769c3000 xvneg.b                XdXj
-769c3400 xvneg.h                XdXj
-769c3800 xvneg.w                XdXj
-769c3c00 xvneg.d                XdXj
+769c3000 xvneg.b                XdXj            @qemu
+769c3400 xvneg.h                XdXj            @qemu
+769c3800 xvneg.w                XdXj            @qemu
+769c3c00 xvneg.d                XdXj            @qemu
 769c4000 xvmskltz.b             XdXj
 769c4400 xvmskltz.h             XdXj
 769c4800 xvmskltz.w             XdXj
@@ -580,10 +580,10 @@
 769ef400 xvexth.wu.hu           XdXj
 769ef800 xvexth.du.wu           XdXj
 769efc00 xvexth.qu.du           XdXj
-769f0000 xvreplgr2vr.b          XdJ
-769f0400 xvreplgr2vr.h          XdJ
-769f0800 xvreplgr2vr.w          XdJ
-769f0c00 xvreplgr2vr.d          XdJ
+769f0000 xvreplgr2vr.b          XdJ             @qemu
+769f0400 xvreplgr2vr.h          XdJ             @qemu
+769f0800 xvreplgr2vr.w          XdJ             @qemu
+769f0c00 xvreplgr2vr.d          XdJ             @qemu
 769f1000 vext2xv.h.b            XdXj
 769f1400 vext2xv.w.b            XdXj
 769f1800 vext2xv.d.b            XdXj
@@ -596,10 +596,10 @@
 769f3400 vext2xv.wu.hu          XdXj
 769f3800 vext2xv.du.hu          XdXj
 769f3c00 vext2xv.du.wu          XdXj
-76a02000 xvrotri.b              XdXjUk3
-76a04000 xvrotri.h              XdXjUk4
-76a08000 xvrotri.w              XdXjUk5
-76a10000 xvrotri.d              XdXjUk6
+76a02000 xvrotri.b              XdXjUk3        @qemu
+76a04000 xvrotri.h              XdXjUk4        @qemu
+76a08000 xvrotri.w              XdXjUk5        @qemu
+76a10000 xvrotri.d              XdXjUk6        @qemu
 76a42000 xvsrlri.b              XdXjUk3
 76a44000 xvsrlri.h              XdXjUk4
 76a48000 xvsrlri.w              XdXjUk5
@@ -608,25 +608,25 @@
 76a84000 xvsrari.h              XdXjUk4
 76a88000 xvsrari.w              XdXjUk5
 76a90000 xvsrari.d              XdXjUk6
-76ebc000 xvinsgr2vr.w           XdJUk3
-76ebe000 xvinsgr2vr.d           XdJUk2
-76efc000 xvpickve2gr.w          DXjUk3
-76efe000 xvpickve2gr.d          DXjUk2
-76f3c000 xvpickve2gr.wu         DXjUk3
-76f3e000 xvpickve2gr.du         DXjUk2
-76f78000 xvrepl128vei.b         XdXjUk4
-76f7c000 xvrepl128vei.h         XdXjUk3
-76f7e000 xvrepl128vei.w         XdXjUk2
-76f7f000 xvrepl128vei.d         XdXjUk1
+76ebc000 xvinsgr2vr.w           XdJUk3          @qemu
+76ebe000 xvinsgr2vr.d           XdJUk2          @qemu
+76efc000 xvpickve2gr.w          DXjUk3          @qemu
+76efe000 xvpickve2gr.d          DXjUk2          @qemu
+76f3c000 xvpickve2gr.wu         DXjUk3          @qemu
+76f3e000 xvpickve2gr.du         DXjUk2          @qemu
+76f78000 xvrepl128vei.b         XdXjUk4         @qemu
+76f7c000 xvrepl128vei.h         XdXjUk3         @qemu
+76f7e000 xvrepl128vei.w         XdXjUk2         @qemu
+76f7f000 xvrepl128vei.d         XdXjUk1         @qemu
 76ffc000 xvinsve0.w             XdXjUk3
 76ffe000 xvinsve0.d             XdXjUk2
 7703c000 xvpickve.w             XdXjUk3
 7703e000 xvpickve.d             XdXjUk2
-77070000 xvreplve0.b            XdXj
-77078000 xvreplve0.h            XdXj
-7707c000 xvreplve0.w            XdXj
-7707e000 xvreplve0.d            XdXj
-7707f000 xvreplve0.q            XdXj
+77070000 xvreplve0.b            XdXj            @qemu
+77078000 xvreplve0.h            XdXj            @qemu
+7707c000 xvreplve0.w            XdXj            @qemu
+7707e000 xvreplve0.d            XdXj            @qemu
+7707f000 xvreplve0.q            XdXj            @qemu
 77082000 xvsllwil.h.b           XdXjUk3
 77084000 xvsllwil.w.h           XdXjUk4
 77088000 xvsllwil.d.w           XdXjUk5
@@ -635,18 +635,18 @@
 770c4000 xvsllwil.wu.hu         XdXjUk4
 770c8000 xvsllwil.du.wu         XdXjUk5
 770d0000 xvextl.qu.du           XdXj
-77102000 xvbitclri.b            XdXjUk3
-77104000 xvbitclri.h            XdXjUk4
-77108000 xvbitclri.w            XdXjUk5
-77110000 xvbitclri.d            XdXjUk6
-77142000 xvbitseti.b            XdXjUk3
-77144000 xvbitseti.h            XdXjUk4
-77148000 xvbitseti.w            XdXjUk5
-77150000 xvbitseti.d            XdXjUk6
-77182000 xvbitrevi.b            XdXjUk3
-77184000 xvbitrevi.h            XdXjUk4
-77188000 xvbitrevi.w            XdXjUk5
-77190000 xvbitrevi.d            XdXjUk6
+77102000 xvbitclri.b            XdXjUk3         @qemu
+77104000 xvbitclri.h            XdXjUk4         @qemu
+77108000 xvbitclri.w            XdXjUk5         @qemu
+77110000 xvbitclri.d            XdXjUk6         @qemu
+77142000 xvbitseti.b            XdXjUk3         @qemu
+77144000 xvbitseti.h            XdXjUk4         @qemu
+77148000 xvbitseti.w            XdXjUk5         @qemu
+77150000 xvbitseti.d            XdXjUk6         @qemu
+77182000 xvbitrevi.b            XdXjUk3         @qemu
+77184000 xvbitrevi.h            XdXjUk4         @qemu
+77188000 xvbitrevi.w            XdXjUk5         @qemu
+77190000 xvbitrevi.d            XdXjUk6         @qemu
 77242000 xvsat.b                XdXjUk3
 77244000 xvsat.h                XdXjUk4
 77248000 xvsat.w                XdXjUk5
@@ -655,18 +655,18 @@
 77284000 xvsat.hu               XdXjUk4
 77288000 xvsat.wu               XdXjUk5
 77290000 xvsat.du               XdXjUk6
-772c2000 xvslli.b               XdXjUk3
-772c4000 xvslli.h               XdXjUk4
-772c8000 xvslli.w               XdXjUk5
-772d0000 xvslli.d               XdXjUk6
-77302000 xvsrli.b               XdXjUk3
-77304000 xvsrli.h               XdXjUk4
-77308000 xvsrli.w               XdXjUk5
-77310000 xvsrli.d               XdXjUk6
-77342000 xvsrai.b               XdXjUk3
-77344000 xvsrai.h               XdXjUk4
-77348000 xvsrai.w               XdXjUk5
-77350000 xvsrai.d               XdXjUk6
+772c2000 xvslli.b               XdXjUk3         @qemu
+772c4000 xvslli.h               XdXjUk4         @qemu
+772c8000 xvslli.w               XdXjUk5         @qemu
+772d0000 xvslli.d               XdXjUk6         @qemu
+77302000 xvsrli.b               XdXjUk3         @qemu
+77304000 xvsrli.h               XdXjUk4         @qemu
+77308000 xvsrli.w               XdXjUk5         @qemu
+77310000 xvsrli.d               XdXjUk6         @qemu
+77342000 xvsrai.b               XdXjUk3         @qemu
+77344000 xvsrai.h               XdXjUk4         @qemu
+77348000 xvsrai.w               XdXjUk5         @qemu
+77350000 xvsrai.d               XdXjUk6         @qemu
 77404000 xvsrlni.b.h            XdXjUk4
 77408000 xvsrlni.h.w            XdXjUk5
 77410000 xvsrlni.w.d            XdXjUk6
@@ -723,12 +723,12 @@
 77940000 xvshuf4i.h             XdXjUk8
 77980000 xvshuf4i.w             XdXjUk8
 779c0000 xvshuf4i.d             XdXjUk8
-77c40000 xvbitseli.b            XdXjUk8
-77d00000 xvandi.b               XdXjUk8
-77d40000 xvori.b                XdXjUk8
-77d80000 xvxori.b               XdXjUk8
-77dc0000 xvnori.b               XdXjUk8
-77e00000 xvldi                  XdSj13
+77c40000 xvbitseli.b            XdXjUk8         @qemu
+77d00000 xvandi.b               XdXjUk8         @qemu
+77d40000 xvori.b                XdXjUk8         @qemu
+77d80000 xvxori.b               XdXjUk8         @qemu
+77dc0000 xvnori.b               XdXjUk8         @qemu
+77e00000 xvldi                  XdSj13          @qemu
 77e40000 xvpermi.w              XdXjUk8
 77e80000 xvpermi.d              XdXjUk8
 77ec0000 xvpermi.q              XdXjUk8

--- a/lsx.txt
+++ b/lsx.txt
@@ -1,55 +1,55 @@
-09100000 vfmadd.s               VdVjVkVa        @qemu
-09200000 vfmadd.d               VdVjVkVa        @qemu
-09500000 vfmsub.s               VdVjVkVa        @qemu
-09600000 vfmsub.d               VdVjVkVa        @qemu
-09900000 vfnmadd.s              VdVjVkVa        @qemu
-09a00000 vfnmadd.d              VdVjVkVa        @qemu
-09d00000 vfnmsub.s              VdVjVkVa        @qemu
-09e00000 vfnmsub.d              VdVjVkVa        @qemu
-0c500000 vfcmp.caf.s            VdVjVk          @qemu
-0c508000 vfcmp.saf.s            VdVjVk          @qemu
-0c510000 vfcmp.clt.s            VdVjVk          @qemu
-0c518000 vfcmp.slt.s            VdVjVk          @qemu
-0c520000 vfcmp.ceq.s            VdVjVk          @qemu
-0c528000 vfcmp.seq.s            VdVjVk          @qemu
-0c530000 vfcmp.cle.s            VdVjVk          @qemu
-0c538000 vfcmp.sle.s            VdVjVk          @qemu
-0c540000 vfcmp.cun.s            VdVjVk          @qemu
-0c548000 vfcmp.sun.s            VdVjVk          @qemu
-0c550000 vfcmp.cult.s           VdVjVk          @qemu
-0c558000 vfcmp.sult.s           VdVjVk          @qemu
-0c560000 vfcmp.cueq.s           VdVjVk          @qemu
-0c568000 vfcmp.sueq.s           VdVjVk          @qemu
-0c570000 vfcmp.cule.s           VdVjVk          @qemu
-0c578000 vfcmp.sule.s           VdVjVk          @qemu
-0c580000 vfcmp.cne.s            VdVjVk          @qemu
-0c588000 vfcmp.sne.s            VdVjVk          @qemu
-0c5a0000 vfcmp.cor.s            VdVjVk          @qemu
-0c5a8000 vfcmp.sor.s            VdVjVk          @qemu
-0c5c0000 vfcmp.cune.s           VdVjVk          @qemu
-0c5c8000 vfcmp.sune.s           VdVjVk          @qemu
-0c600000 vfcmp.caf.d            VdVjVk          @qemu
-0c608000 vfcmp.saf.d            VdVjVk          @qemu
-0c610000 vfcmp.clt.d            VdVjVk          @qemu
-0c618000 vfcmp.slt.d            VdVjVk          @qemu
-0c620000 vfcmp.ceq.d            VdVjVk          @qemu
-0c628000 vfcmp.seq.d            VdVjVk          @qemu
-0c630000 vfcmp.cle.d            VdVjVk          @qemu
-0c638000 vfcmp.sle.d            VdVjVk          @qemu
-0c640000 vfcmp.cun.d            VdVjVk          @qemu
-0c648000 vfcmp.sun.d            VdVjVk          @qemu
-0c650000 vfcmp.cult.d           VdVjVk          @qemu
-0c658000 vfcmp.sult.d           VdVjVk          @qemu
-0c660000 vfcmp.cueq.d           VdVjVk          @qemu
-0c668000 vfcmp.sueq.d           VdVjVk          @qemu
-0c670000 vfcmp.cule.d           VdVjVk          @qemu
-0c678000 vfcmp.sule.d           VdVjVk          @qemu
-0c680000 vfcmp.cne.d            VdVjVk          @qemu
-0c688000 vfcmp.sne.d            VdVjVk          @qemu
-0c6a0000 vfcmp.cor.d            VdVjVk          @qemu
-0c6a8000 vfcmp.sor.d            VdVjVk          @qemu
-0c6c0000 vfcmp.cune.d           VdVjVk          @qemu
-0c6c8000 vfcmp.sune.d           VdVjVk          @qemu
+09100000 vfmadd.s               VdVjVkVa
+09200000 vfmadd.d               VdVjVkVa
+09500000 vfmsub.s               VdVjVkVa
+09600000 vfmsub.d               VdVjVkVa
+09900000 vfnmadd.s              VdVjVkVa
+09a00000 vfnmadd.d              VdVjVkVa
+09d00000 vfnmsub.s              VdVjVkVa
+09e00000 vfnmsub.d              VdVjVkVa
+0c500000 vfcmp.caf.s            VdVjVk
+0c508000 vfcmp.saf.s            VdVjVk
+0c510000 vfcmp.clt.s            VdVjVk
+0c518000 vfcmp.slt.s            VdVjVk
+0c520000 vfcmp.ceq.s            VdVjVk
+0c528000 vfcmp.seq.s            VdVjVk
+0c530000 vfcmp.cle.s            VdVjVk
+0c538000 vfcmp.sle.s            VdVjVk
+0c540000 vfcmp.cun.s            VdVjVk
+0c548000 vfcmp.sun.s            VdVjVk
+0c550000 vfcmp.cult.s           VdVjVk
+0c558000 vfcmp.sult.s           VdVjVk
+0c560000 vfcmp.cueq.s           VdVjVk
+0c568000 vfcmp.sueq.s           VdVjVk
+0c570000 vfcmp.cule.s           VdVjVk
+0c578000 vfcmp.sule.s           VdVjVk
+0c580000 vfcmp.cne.s            VdVjVk
+0c588000 vfcmp.sne.s            VdVjVk
+0c5a0000 vfcmp.cor.s            VdVjVk
+0c5a8000 vfcmp.sor.s            VdVjVk
+0c5c0000 vfcmp.cune.s           VdVjVk
+0c5c8000 vfcmp.sune.s           VdVjVk
+0c600000 vfcmp.caf.d            VdVjVk
+0c608000 vfcmp.saf.d            VdVjVk
+0c610000 vfcmp.clt.d            VdVjVk
+0c618000 vfcmp.slt.d            VdVjVk
+0c620000 vfcmp.ceq.d            VdVjVk
+0c628000 vfcmp.seq.d            VdVjVk
+0c630000 vfcmp.cle.d            VdVjVk
+0c638000 vfcmp.sle.d            VdVjVk
+0c640000 vfcmp.cun.d            VdVjVk
+0c648000 vfcmp.sun.d            VdVjVk
+0c650000 vfcmp.cult.d           VdVjVk
+0c658000 vfcmp.sult.d           VdVjVk
+0c660000 vfcmp.cueq.d           VdVjVk
+0c668000 vfcmp.sueq.d           VdVjVk
+0c670000 vfcmp.cule.d           VdVjVk
+0c678000 vfcmp.sule.d           VdVjVk
+0c680000 vfcmp.cne.d            VdVjVk
+0c688000 vfcmp.sne.d            VdVjVk
+0c6a0000 vfcmp.cor.d            VdVjVk
+0c6a8000 vfcmp.sor.d            VdVjVk
+0c6c0000 vfcmp.cune.d           VdVjVk
+0c6c8000 vfcmp.sune.d           VdVjVk
 0d100000 vbitsel.v              VdVjVkVa        @qemu
 0d500000 vshuf.b                VdVjVkVa        @qemu
 2c000000 vld                    VdJSk12         @qemu
@@ -92,46 +92,46 @@
 700c8000 vsub.h                 VdVjVk          @qemu
 700d0000 vsub.w                 VdVjVk          @qemu
 700d8000 vsub.d                 VdVjVk          @qemu
-701e0000 vaddwev.h.b            VdVjVk          @qemu
-701e8000 vaddwev.w.h            VdVjVk          @qemu
-701f0000 vaddwev.d.w            VdVjVk          @qemu
-701f8000 vaddwev.q.d            VdVjVk          @qemu
-70200000 vsubwev.h.b            VdVjVk          @qemu
-70208000 vsubwev.w.h            VdVjVk          @qemu
-70210000 vsubwev.d.w            VdVjVk          @qemu
-70218000 vsubwev.q.d            VdVjVk          @qemu
-70220000 vaddwod.h.b            VdVjVk          @qemu
-70228000 vaddwod.w.h            VdVjVk          @qemu
-70230000 vaddwod.d.w            VdVjVk          @qemu
-70238000 vaddwod.q.d            VdVjVk          @qemu
-70240000 vsubwod.h.b            VdVjVk          @qemu
-70248000 vsubwod.w.h            VdVjVk          @qemu
-70250000 vsubwod.d.w            VdVjVk          @qemu
-70258000 vsubwod.q.d            VdVjVk          @qemu
-702e0000 vaddwev.h.bu           VdVjVk          @qemu
-702e8000 vaddwev.w.hu           VdVjVk          @qemu
-702f0000 vaddwev.d.wu           VdVjVk          @qemu
-702f8000 vaddwev.q.du           VdVjVk          @qemu
-70300000 vsubwev.h.bu           VdVjVk          @qemu
-70308000 vsubwev.w.hu           VdVjVk          @qemu
-70310000 vsubwev.d.wu           VdVjVk          @qemu
-70318000 vsubwev.q.du           VdVjVk          @qemu
-70320000 vaddwod.h.bu           VdVjVk          @qemu
-70328000 vaddwod.w.hu           VdVjVk          @qemu
-70330000 vaddwod.d.wu           VdVjVk          @qemu
-70338000 vaddwod.q.du           VdVjVk          @qemu
-70340000 vsubwod.h.bu           VdVjVk          @qemu
-70348000 vsubwod.w.hu           VdVjVk          @qemu
-70350000 vsubwod.d.wu           VdVjVk          @qemu
-70358000 vsubwod.q.du           VdVjVk          @qemu
-703e0000 vaddwev.h.bu.b         VdVjVk          @qemu
-703e8000 vaddwev.w.hu.h         VdVjVk          @qemu
-703f0000 vaddwev.d.wu.w         VdVjVk          @qemu
-703f8000 vaddwev.q.du.d         VdVjVk          @qemu
-70400000 vaddwod.h.bu.b         VdVjVk          @qemu
-70408000 vaddwod.w.hu.h         VdVjVk          @qemu
-70410000 vaddwod.d.wu.w         VdVjVk          @qemu
-70418000 vaddwod.q.du.d         VdVjVk          @qemu
+701e0000 vaddwev.h.b            VdVjVk
+701e8000 vaddwev.w.h            VdVjVk
+701f0000 vaddwev.d.w            VdVjVk
+701f8000 vaddwev.q.d            VdVjVk
+70200000 vsubwev.h.b            VdVjVk
+70208000 vsubwev.w.h            VdVjVk
+70210000 vsubwev.d.w            VdVjVk
+70218000 vsubwev.q.d            VdVjVk
+70220000 vaddwod.h.b            VdVjVk
+70228000 vaddwod.w.h            VdVjVk
+70230000 vaddwod.d.w            VdVjVk
+70238000 vaddwod.q.d            VdVjVk
+70240000 vsubwod.h.b            VdVjVk
+70248000 vsubwod.w.h            VdVjVk
+70250000 vsubwod.d.w            VdVjVk
+70258000 vsubwod.q.d            VdVjVk
+702e0000 vaddwev.h.bu           VdVjVk
+702e8000 vaddwev.w.hu           VdVjVk
+702f0000 vaddwev.d.wu           VdVjVk
+702f8000 vaddwev.q.du           VdVjVk
+70300000 vsubwev.h.bu           VdVjVk
+70308000 vsubwev.w.hu           VdVjVk
+70310000 vsubwev.d.wu           VdVjVk
+70318000 vsubwev.q.du           VdVjVk
+70320000 vaddwod.h.bu           VdVjVk
+70328000 vaddwod.w.hu           VdVjVk
+70330000 vaddwod.d.wu           VdVjVk
+70338000 vaddwod.q.du           VdVjVk
+70340000 vsubwod.h.bu           VdVjVk
+70348000 vsubwod.w.hu           VdVjVk
+70350000 vsubwod.d.wu           VdVjVk
+70358000 vsubwod.q.du           VdVjVk
+703e0000 vaddwev.h.bu.b         VdVjVk
+703e8000 vaddwev.w.hu.h         VdVjVk
+703f0000 vaddwev.d.wu.w         VdVjVk
+703f8000 vaddwev.q.du.d         VdVjVk
+70400000 vaddwod.h.bu.b         VdVjVk
+70408000 vaddwod.w.hu.h         VdVjVk
+70410000 vaddwod.d.wu.w         VdVjVk
+70418000 vaddwod.q.du.d         VdVjVk
 70460000 vsadd.b                VdVjVk          @qemu
 70468000 vsadd.h                VdVjVk          @qemu
 70470000 vsadd.w                VdVjVk          @qemu
@@ -148,50 +148,50 @@
 704c8000 vssub.hu               VdVjVk          @qemu
 704d0000 vssub.wu               VdVjVk          @qemu
 704d8000 vssub.du               VdVjVk          @qemu
-70540000 vhaddw.h.b             VdVjVk          @qemu
-70548000 vhaddw.w.h             VdVjVk          @qemu
-70550000 vhaddw.d.w             VdVjVk          @qemu
-70558000 vhaddw.q.d             VdVjVk          @qemu
-70560000 vhsubw.h.b             VdVjVk          @qemu
-70568000 vhsubw.w.h             VdVjVk          @qemu
-70570000 vhsubw.d.w             VdVjVk          @qemu
-70578000 vhsubw.q.d             VdVjVk          @qemu
-70580000 vhaddw.hu.bu           VdVjVk          @qemu
-70588000 vhaddw.wu.hu           VdVjVk          @qemu
-70590000 vhaddw.du.wu           VdVjVk          @qemu
-70598000 vhaddw.qu.du           VdVjVk          @qemu
-705a0000 vhsubw.hu.bu           VdVjVk          @qemu
-705a8000 vhsubw.wu.hu           VdVjVk          @qemu
-705b0000 vhsubw.du.wu           VdVjVk          @qemu
-705b8000 vhsubw.qu.du           VdVjVk          @qemu
-705c0000 vadda.b                VdVjVk          @qemu
-705c8000 vadda.h                VdVjVk          @qemu
-705d0000 vadda.w                VdVjVk          @qemu
-705d8000 vadda.d                VdVjVk          @qemu
-70600000 vabsd.b                VdVjVk          @qemu
-70608000 vabsd.h                VdVjVk          @qemu
-70610000 vabsd.w                VdVjVk          @qemu
-70618000 vabsd.d                VdVjVk          @qemu
-70620000 vabsd.bu               VdVjVk          @qemu
-70628000 vabsd.hu               VdVjVk          @qemu
-70630000 vabsd.wu               VdVjVk          @qemu
-70638000 vabsd.du               VdVjVk          @qemu
-70640000 vavg.b                 VdVjVk          @qemu
-70648000 vavg.h                 VdVjVk          @qemu
-70650000 vavg.w                 VdVjVk          @qemu
-70658000 vavg.d                 VdVjVk          @qemu
-70660000 vavg.bu                VdVjVk          @qemu
-70668000 vavg.hu                VdVjVk          @qemu
-70670000 vavg.wu                VdVjVk          @qemu
-70678000 vavg.du                VdVjVk          @qemu
-70680000 vavgr.b                VdVjVk          @qemu
-70688000 vavgr.h                VdVjVk          @qemu
-70690000 vavgr.w                VdVjVk          @qemu
-70698000 vavgr.d                VdVjVk          @qemu
-706a0000 vavgr.bu               VdVjVk          @qemu
-706a8000 vavgr.hu               VdVjVk          @qemu
-706b0000 vavgr.wu               VdVjVk          @qemu
-706b8000 vavgr.du               VdVjVk          @qemu
+70540000 vhaddw.h.b             VdVjVk
+70548000 vhaddw.w.h             VdVjVk
+70550000 vhaddw.d.w             VdVjVk
+70558000 vhaddw.q.d             VdVjVk
+70560000 vhsubw.h.b             VdVjVk
+70568000 vhsubw.w.h             VdVjVk
+70570000 vhsubw.d.w             VdVjVk
+70578000 vhsubw.q.d             VdVjVk
+70580000 vhaddw.hu.bu           VdVjVk
+70588000 vhaddw.wu.hu           VdVjVk
+70590000 vhaddw.du.wu           VdVjVk
+70598000 vhaddw.qu.du           VdVjVk
+705a0000 vhsubw.hu.bu           VdVjVk
+705a8000 vhsubw.wu.hu           VdVjVk
+705b0000 vhsubw.du.wu           VdVjVk
+705b8000 vhsubw.qu.du           VdVjVk
+705c0000 vadda.b                VdVjVk
+705c8000 vadda.h                VdVjVk
+705d0000 vadda.w                VdVjVk
+705d8000 vadda.d                VdVjVk
+70600000 vabsd.b                VdVjVk
+70608000 vabsd.h                VdVjVk
+70610000 vabsd.w                VdVjVk
+70618000 vabsd.d                VdVjVk
+70620000 vabsd.bu               VdVjVk
+70628000 vabsd.hu               VdVjVk
+70630000 vabsd.wu               VdVjVk
+70638000 vabsd.du               VdVjVk
+70640000 vavg.b                 VdVjVk
+70648000 vavg.h                 VdVjVk
+70650000 vavg.w                 VdVjVk
+70658000 vavg.d                 VdVjVk
+70660000 vavg.bu                VdVjVk
+70668000 vavg.hu                VdVjVk
+70670000 vavg.wu                VdVjVk
+70678000 vavg.du                VdVjVk
+70680000 vavgr.b                VdVjVk
+70688000 vavgr.h                VdVjVk
+70690000 vavgr.w                VdVjVk
+70698000 vavgr.d                VdVjVk
+706a0000 vavgr.bu               VdVjVk
+706a8000 vavgr.hu               VdVjVk
+706b0000 vavgr.wu               VdVjVk
+706b8000 vavgr.du               VdVjVk
 70700000 vmax.b                 VdVjVk          @qemu
 70708000 vmax.h                 VdVjVk          @qemu
 70710000 vmax.w                 VdVjVk          @qemu
@@ -212,86 +212,86 @@
 70848000 vmul.h                 VdVjVk          @qemu
 70850000 vmul.w                 VdVjVk          @qemu
 70858000 vmul.d                 VdVjVk          @qemu
-70860000 vmuh.b                 VdVjVk          @qemu
-70868000 vmuh.h                 VdVjVk          @qemu
-70870000 vmuh.w                 VdVjVk          @qemu
-70878000 vmuh.d                 VdVjVk          @qemu
-70880000 vmuh.bu                VdVjVk          @qemu
-70888000 vmuh.hu                VdVjVk          @qemu
-70890000 vmuh.wu                VdVjVk          @qemu
-70898000 vmuh.du                VdVjVk          @qemu
-70900000 vmulwev.h.b            VdVjVk          @qemu
-70908000 vmulwev.w.h            VdVjVk          @qemu
-70910000 vmulwev.d.w            VdVjVk          @qemu
-70918000 vmulwev.q.d            VdVjVk          @qemu
-70920000 vmulwod.h.b            VdVjVk          @qemu
-70928000 vmulwod.w.h            VdVjVk          @qemu
-70930000 vmulwod.d.w            VdVjVk          @qemu
-70938000 vmulwod.q.d            VdVjVk          @qemu
-70980000 vmulwev.h.bu           VdVjVk          @qemu
-70988000 vmulwev.w.hu           VdVjVk          @qemu
-70990000 vmulwev.d.wu           VdVjVk          @qemu
-70998000 vmulwev.q.du           VdVjVk          @qemu
-709a0000 vmulwod.h.bu           VdVjVk          @qemu
-709a8000 vmulwod.w.hu           VdVjVk          @qemu
-709b0000 vmulwod.d.wu           VdVjVk          @qemu
-709b8000 vmulwod.q.du           VdVjVk          @qemu
-70a00000 vmulwev.h.bu.b         VdVjVk          @qemu
-70a08000 vmulwev.w.hu.h         VdVjVk          @qemu
-70a10000 vmulwev.d.wu.w         VdVjVk          @qemu
-70a18000 vmulwev.q.du.d         VdVjVk          @qemu
-70a20000 vmulwod.h.bu.b         VdVjVk          @qemu
-70a28000 vmulwod.w.hu.h         VdVjVk          @qemu
-70a30000 vmulwod.d.wu.w         VdVjVk          @qemu
-70a38000 vmulwod.q.du.d         VdVjVk          @qemu
-70a80000 vmadd.b                VdVjVk          @qemu
-70a88000 vmadd.h                VdVjVk          @qemu
-70a90000 vmadd.w                VdVjVk          @qemu
-70a98000 vmadd.d                VdVjVk          @qemu
-70aa0000 vmsub.b                VdVjVk          @qemu
-70aa8000 vmsub.h                VdVjVk          @qemu
-70ab0000 vmsub.w                VdVjVk          @qemu
-70ab8000 vmsub.d                VdVjVk          @qemu
-70ac0000 vmaddwev.h.b           VdVjVk          @qemu
-70ac8000 vmaddwev.w.h           VdVjVk          @qemu
-70ad0000 vmaddwev.d.w           VdVjVk          @qemu
-70ad8000 vmaddwev.q.d           VdVjVk          @qemu
-70ae0000 vmaddwod.h.b           VdVjVk          @qemu
-70ae8000 vmaddwod.w.h           VdVjVk          @qemu
-70af0000 vmaddwod.d.w           VdVjVk          @qemu
-70af8000 vmaddwod.q.d           VdVjVk          @qemu
-70b40000 vmaddwev.h.bu          VdVjVk          @qemu
-70b48000 vmaddwev.w.hu          VdVjVk          @qemu
-70b50000 vmaddwev.d.wu          VdVjVk          @qemu
-70b58000 vmaddwev.q.du          VdVjVk          @qemu
-70b60000 vmaddwod.h.bu          VdVjVk          @qemu
-70b68000 vmaddwod.w.hu          VdVjVk          @qemu
-70b70000 vmaddwod.d.wu          VdVjVk          @qemu
-70b78000 vmaddwod.q.du          VdVjVk          @qemu
-70bc0000 vmaddwev.h.bu.b        VdVjVk          @qemu
-70bc8000 vmaddwev.w.hu.h        VdVjVk          @qemu
-70bd0000 vmaddwev.d.wu.w        VdVjVk          @qemu
-70bd8000 vmaddwev.q.du.d        VdVjVk          @qemu
-70be0000 vmaddwod.h.bu.b        VdVjVk          @qemu
-70be8000 vmaddwod.w.hu.h        VdVjVk          @qemu
-70bf0000 vmaddwod.d.wu.w        VdVjVk          @qemu
-70bf8000 vmaddwod.q.du.d        VdVjVk          @qemu
-70e00000 vdiv.b                 VdVjVk          @qemu
-70e08000 vdiv.h                 VdVjVk          @qemu
-70e10000 vdiv.w                 VdVjVk          @qemu
-70e18000 vdiv.d                 VdVjVk          @qemu
-70e20000 vmod.b                 VdVjVk          @qemu
-70e28000 vmod.h                 VdVjVk          @qemu
-70e30000 vmod.w                 VdVjVk          @qemu
-70e38000 vmod.d                 VdVjVk          @qemu
-70e40000 vdiv.bu                VdVjVk          @qemu
-70e48000 vdiv.hu                VdVjVk          @qemu
-70e50000 vdiv.wu                VdVjVk          @qemu
-70e58000 vdiv.du                VdVjVk          @qemu
-70e60000 vmod.bu                VdVjVk          @qemu
-70e68000 vmod.hu                VdVjVk          @qemu
-70e70000 vmod.wu                VdVjVk          @qemu
-70e78000 vmod.du                VdVjVk          @qemu
+70860000 vmuh.b                 VdVjVk
+70868000 vmuh.h                 VdVjVk
+70870000 vmuh.w                 VdVjVk
+70878000 vmuh.d                 VdVjVk
+70880000 vmuh.bu                VdVjVk
+70888000 vmuh.hu                VdVjVk
+70890000 vmuh.wu                VdVjVk
+70898000 vmuh.du                VdVjVk
+70900000 vmulwev.h.b            VdVjVk
+70908000 vmulwev.w.h            VdVjVk
+70910000 vmulwev.d.w            VdVjVk
+70918000 vmulwev.q.d            VdVjVk
+70920000 vmulwod.h.b            VdVjVk
+70928000 vmulwod.w.h            VdVjVk
+70930000 vmulwod.d.w            VdVjVk
+70938000 vmulwod.q.d            VdVjVk
+70980000 vmulwev.h.bu           VdVjVk
+70988000 vmulwev.w.hu           VdVjVk
+70990000 vmulwev.d.wu           VdVjVk
+70998000 vmulwev.q.du           VdVjVk
+709a0000 vmulwod.h.bu           VdVjVk
+709a8000 vmulwod.w.hu           VdVjVk
+709b0000 vmulwod.d.wu           VdVjVk
+709b8000 vmulwod.q.du           VdVjVk
+70a00000 vmulwev.h.bu.b         VdVjVk
+70a08000 vmulwev.w.hu.h         VdVjVk
+70a10000 vmulwev.d.wu.w         VdVjVk
+70a18000 vmulwev.q.du.d         VdVjVk
+70a20000 vmulwod.h.bu.b         VdVjVk
+70a28000 vmulwod.w.hu.h         VdVjVk
+70a30000 vmulwod.d.wu.w         VdVjVk
+70a38000 vmulwod.q.du.d         VdVjVk
+70a80000 vmadd.b                VdVjVk
+70a88000 vmadd.h                VdVjVk
+70a90000 vmadd.w                VdVjVk
+70a98000 vmadd.d                VdVjVk
+70aa0000 vmsub.b                VdVjVk
+70aa8000 vmsub.h                VdVjVk
+70ab0000 vmsub.w                VdVjVk
+70ab8000 vmsub.d                VdVjVk
+70ac0000 vmaddwev.h.b           VdVjVk
+70ac8000 vmaddwev.w.h           VdVjVk
+70ad0000 vmaddwev.d.w           VdVjVk
+70ad8000 vmaddwev.q.d           VdVjVk
+70ae0000 vmaddwod.h.b           VdVjVk
+70ae8000 vmaddwod.w.h           VdVjVk
+70af0000 vmaddwod.d.w           VdVjVk
+70af8000 vmaddwod.q.d           VdVjVk
+70b40000 vmaddwev.h.bu          VdVjVk
+70b48000 vmaddwev.w.hu          VdVjVk
+70b50000 vmaddwev.d.wu          VdVjVk
+70b58000 vmaddwev.q.du          VdVjVk
+70b60000 vmaddwod.h.bu          VdVjVk
+70b68000 vmaddwod.w.hu          VdVjVk
+70b70000 vmaddwod.d.wu          VdVjVk
+70b78000 vmaddwod.q.du          VdVjVk
+70bc0000 vmaddwev.h.bu.b        VdVjVk
+70bc8000 vmaddwev.w.hu.h        VdVjVk
+70bd0000 vmaddwev.d.wu.w        VdVjVk
+70bd8000 vmaddwev.q.du.d        VdVjVk
+70be0000 vmaddwod.h.bu.b        VdVjVk
+70be8000 vmaddwod.w.hu.h        VdVjVk
+70bf0000 vmaddwod.d.wu.w        VdVjVk
+70bf8000 vmaddwod.q.du.d        VdVjVk
+70e00000 vdiv.b                 VdVjVk
+70e08000 vdiv.h                 VdVjVk
+70e10000 vdiv.w                 VdVjVk
+70e18000 vdiv.d                 VdVjVk
+70e20000 vmod.b                 VdVjVk
+70e28000 vmod.h                 VdVjVk
+70e30000 vmod.w                 VdVjVk
+70e38000 vmod.d                 VdVjVk
+70e40000 vdiv.bu                VdVjVk
+70e48000 vdiv.hu                VdVjVk
+70e50000 vdiv.wu                VdVjVk
+70e58000 vdiv.du                VdVjVk
+70e60000 vmod.bu                VdVjVk
+70e68000 vmod.hu                VdVjVk
+70e70000 vmod.wu                VdVjVk
+70e78000 vmod.du                VdVjVk
 70e80000 vsll.b                 VdVjVk          @qemu
 70e88000 vsll.h                 VdVjVk          @qemu
 70e90000 vsll.w                 VdVjVk          @qemu
@@ -308,86 +308,86 @@
 70ee8000 vrotr.h                VdVjVk          @qemu
 70ef0000 vrotr.w                VdVjVk          @qemu
 70ef8000 vrotr.d                VdVjVk          @qemu
-70f00000 vsrlr.b                VdVjVk          @qemu
-70f08000 vsrlr.h                VdVjVk          @qemu
-70f10000 vsrlr.w                VdVjVk          @qemu
-70f18000 vsrlr.d                VdVjVk          @qemu
-70f20000 vsrar.b                VdVjVk          @qemu
-70f28000 vsrar.h                VdVjVk          @qemu
-70f30000 vsrar.w                VdVjVk          @qemu
-70f38000 vsrar.d                VdVjVk          @qemu
-70f48000 vsrln.b.h              VdVjVk          @qemu
-70f50000 vsrln.h.w              VdVjVk          @qemu
-70f58000 vsrln.w.d              VdVjVk          @qemu
-70f68000 vsran.b.h              VdVjVk          @qemu
-70f70000 vsran.h.w              VdVjVk          @qemu
-70f78000 vsran.w.d              VdVjVk          @qemu
-70f88000 vsrlrn.b.h             VdVjVk          @qemu
-70f90000 vsrlrn.h.w             VdVjVk          @qemu
-70f98000 vsrlrn.w.d             VdVjVk          @qemu
-70fa8000 vsrarn.b.h             VdVjVk          @qemu
-70fb0000 vsrarn.h.w             VdVjVk          @qemu
-70fb8000 vsrarn.w.d             VdVjVk          @qemu
-70fc8000 vssrln.b.h             VdVjVk          @qemu
-70fd0000 vssrln.h.w             VdVjVk          @qemu
-70fd8000 vssrln.w.d             VdVjVk          @qemu
-70fe8000 vssran.b.h             VdVjVk          @qemu
-70ff0000 vssran.h.w             VdVjVk          @qemu
-70ff8000 vssran.w.d             VdVjVk          @qemu
-71008000 vssrlrn.b.h            VdVjVk          @qemu
-71010000 vssrlrn.h.w            VdVjVk          @qemu
-71018000 vssrlrn.w.d            VdVjVk          @qemu
-71028000 vssrarn.b.h            VdVjVk          @qemu
-71030000 vssrarn.h.w            VdVjVk          @qemu
-71038000 vssrarn.w.d            VdVjVk          @qemu
-71048000 vssrln.bu.h            VdVjVk          @qemu
-71050000 vssrln.hu.w            VdVjVk          @qemu
-71058000 vssrln.wu.d            VdVjVk          @qemu
-71068000 vssran.bu.h            VdVjVk          @qemu
-71070000 vssran.hu.w            VdVjVk          @qemu
-71078000 vssran.wu.d            VdVjVk          @qemu
-71088000 vssrlrn.bu.h           VdVjVk          @qemu
-71090000 vssrlrn.hu.w           VdVjVk          @qemu
-71098000 vssrlrn.wu.d           VdVjVk          @qemu
-710a8000 vssrarn.bu.h           VdVjVk          @qemu
-710b0000 vssrarn.hu.w           VdVjVk          @qemu
-710b8000 vssrarn.wu.d           VdVjVk          @qemu
-710c0000 vbitclr.b              VdVjVk          @qemu
-710c8000 vbitclr.h              VdVjVk          @qemu
-710d0000 vbitclr.w              VdVjVk          @qemu
-710d8000 vbitclr.d              VdVjVk          @qemu
-710e0000 vbitset.b              VdVjVk          @qemu
-710e8000 vbitset.h              VdVjVk          @qemu
-710f0000 vbitset.w              VdVjVk          @qemu
-710f8000 vbitset.d              VdVjVk          @qemu
-71100000 vbitrev.b              VdVjVk          @qemu
-71108000 vbitrev.h              VdVjVk          @qemu
-71110000 vbitrev.w              VdVjVk          @qemu
-71118000 vbitrev.d              VdVjVk          @qemu
-71160000 vpackev.b              VdVjVk          @qemu
-71168000 vpackev.h              VdVjVk          @qemu
-71170000 vpackev.w              VdVjVk          @qemu
-71178000 vpackev.d              VdVjVk          @qemu
-71180000 vpackod.b              VdVjVk          @qemu
-71188000 vpackod.h              VdVjVk          @qemu
-71190000 vpackod.w              VdVjVk          @qemu
-71198000 vpackod.d              VdVjVk          @qemu
-711a0000 vilvl.b                VdVjVk          @qemu
-711a8000 vilvl.h                VdVjVk          @qemu
-711b0000 vilvl.w                VdVjVk          @qemu
-711b8000 vilvl.d                VdVjVk          @qemu
-711c0000 vilvh.b                VdVjVk          @qemu
-711c8000 vilvh.h                VdVjVk          @qemu
-711d0000 vilvh.w                VdVjVk          @qemu
-711d8000 vilvh.d                VdVjVk          @qemu
-711e0000 vpickev.b              VdVjVk          @qemu
-711e8000 vpickev.h              VdVjVk          @qemu
-711f0000 vpickev.w              VdVjVk          @qemu
-711f8000 vpickev.d              VdVjVk          @qemu
-71200000 vpickod.b              VdVjVk          @qemu
-71208000 vpickod.h              VdVjVk          @qemu
-71210000 vpickod.w              VdVjVk          @qemu
-71218000 vpickod.d              VdVjVk          @qemu
+70f00000 vsrlr.b                VdVjVk
+70f08000 vsrlr.h                VdVjVk
+70f10000 vsrlr.w                VdVjVk
+70f18000 vsrlr.d                VdVjVk
+70f20000 vsrar.b                VdVjVk
+70f28000 vsrar.h                VdVjVk
+70f30000 vsrar.w                VdVjVk
+70f38000 vsrar.d                VdVjVk
+70f48000 vsrln.b.h              VdVjVk
+70f50000 vsrln.h.w              VdVjVk
+70f58000 vsrln.w.d              VdVjVk
+70f68000 vsran.b.h              VdVjVk
+70f70000 vsran.h.w              VdVjVk
+70f78000 vsran.w.d              VdVjVk
+70f88000 vsrlrn.b.h             VdVjVk
+70f90000 vsrlrn.h.w             VdVjVk
+70f98000 vsrlrn.w.d             VdVjVk
+70fa8000 vsrarn.b.h             VdVjVk
+70fb0000 vsrarn.h.w             VdVjVk
+70fb8000 vsrarn.w.d             VdVjVk
+70fc8000 vssrln.b.h             VdVjVk
+70fd0000 vssrln.h.w             VdVjVk
+70fd8000 vssrln.w.d             VdVjVk
+70fe8000 vssran.b.h             VdVjVk
+70ff0000 vssran.h.w             VdVjVk
+70ff8000 vssran.w.d             VdVjVk
+71008000 vssrlrn.b.h            VdVjVk
+71010000 vssrlrn.h.w            VdVjVk
+71018000 vssrlrn.w.d            VdVjVk
+71028000 vssrarn.b.h            VdVjVk
+71030000 vssrarn.h.w            VdVjVk
+71038000 vssrarn.w.d            VdVjVk
+71048000 vssrln.bu.h            VdVjVk
+71050000 vssrln.hu.w            VdVjVk
+71058000 vssrln.wu.d            VdVjVk
+71068000 vssran.bu.h            VdVjVk
+71070000 vssran.hu.w            VdVjVk
+71078000 vssran.wu.d            VdVjVk
+71088000 vssrlrn.bu.h           VdVjVk
+71090000 vssrlrn.hu.w           VdVjVk
+71098000 vssrlrn.wu.d           VdVjVk
+710a8000 vssrarn.bu.h           VdVjVk
+710b0000 vssrarn.hu.w           VdVjVk
+710b8000 vssrarn.wu.d           VdVjVk
+710c0000 vbitclr.b              VdVjVk
+710c8000 vbitclr.h              VdVjVk
+710d0000 vbitclr.w              VdVjVk
+710d8000 vbitclr.d              VdVjVk
+710e0000 vbitset.b              VdVjVk
+710e8000 vbitset.h              VdVjVk
+710f0000 vbitset.w              VdVjVk
+710f8000 vbitset.d              VdVjVk
+71100000 vbitrev.b              VdVjVk
+71108000 vbitrev.h              VdVjVk
+71110000 vbitrev.w              VdVjVk
+71118000 vbitrev.d              VdVjVk
+71160000 vpackev.b              VdVjVk
+71168000 vpackev.h              VdVjVk
+71170000 vpackev.w              VdVjVk
+71178000 vpackev.d              VdVjVk
+71180000 vpackod.b              VdVjVk
+71188000 vpackod.h              VdVjVk
+71190000 vpackod.w              VdVjVk
+71198000 vpackod.d              VdVjVk
+711a0000 vilvl.b                VdVjVk
+711a8000 vilvl.h                VdVjVk
+711b0000 vilvl.w                VdVjVk
+711b8000 vilvl.d                VdVjVk
+711c0000 vilvh.b                VdVjVk
+711c8000 vilvh.h                VdVjVk
+711d0000 vilvh.w                VdVjVk
+711d8000 vilvh.d                VdVjVk
+711e0000 vpickev.b              VdVjVk
+711e8000 vpickev.h              VdVjVk
+711f0000 vpickev.w              VdVjVk
+711f8000 vpickev.d              VdVjVk
+71200000 vpickod.b              VdVjVk
+71208000 vpickod.h              VdVjVk
+71210000 vpickod.w              VdVjVk
+71218000 vpickod.d              VdVjVk
 71220000 vreplve.b              VdVjK           @qemu
 71228000 vreplve.h              VdVjK           @qemu
 71230000 vreplve.w              VdVjK           @qemu
@@ -398,41 +398,41 @@
 71278000 vnor.v                 VdVjVk          @qemu
 71280000 vandn.v                VdVjVk          @qemu
 71288000 vorn.v                 VdVjVk          @qemu
-712b0000 vfrstp.b               VdVjVk          @qemu
-712b8000 vfrstp.h               VdVjVk          @qemu
-712d0000 vadd.q                 VdVjVk          @qemu
-712d8000 vsub.q                 VdVjVk          @qemu
-712e0000 vsigncov.b             VdVjVk          @qemu
-712e8000 vsigncov.h             VdVjVk          @qemu
-712f0000 vsigncov.w             VdVjVk          @qemu
-712f8000 vsigncov.d             VdVjVk          @qemu
-71308000 vfadd.s                VdVjVk          @qemu
-71310000 vfadd.d                VdVjVk          @qemu
-71328000 vfsub.s                VdVjVk          @qemu
-71330000 vfsub.d                VdVjVk          @qemu
-71388000 vfmul.s                VdVjVk          @qemu
-71390000 vfmul.d                VdVjVk          @qemu
-713a8000 vfdiv.s                VdVjVk          @qemu
-713b0000 vfdiv.d                VdVjVk          @qemu
-713c8000 vfmax.s                VdVjVk          @qemu
-713d0000 vfmax.d                VdVjVk          @qemu
-713e8000 vfmin.s                VdVjVk          @qemu
-713f0000 vfmin.d                VdVjVk          @qemu
-71408000 vfmaxa.s               VdVjVk          @qemu
-71410000 vfmaxa.d               VdVjVk          @qemu
-71428000 vfmina.s               VdVjVk          @qemu
-71430000 vfmina.d               VdVjVk          @qemu
-71460000 vfcvt.h.s              VdVjVk          @qemu
-71468000 vfcvt.s.d              VdVjVk          @qemu
-71480000 vffint.s.l             VdVjVk          @qemu
-71498000 vftint.w.d             VdVjVk          @qemu
-714a0000 vftintrm.w.d           VdVjVk          @qemu
-714a8000 vftintrp.w.d           VdVjVk          @qemu
-714b0000 vftintrz.w.d           VdVjVk          @qemu
-714b8000 vftintrne.w.d          VdVjVk          @qemu
-717a8000 vshuf.h                VdVjVk          @qemu
-717b0000 vshuf.w                VdVjVk          @qemu
-717b8000 vshuf.d                VdVjVk          @qemu
+712b0000 vfrstp.b               VdVjVk
+712b8000 vfrstp.h               VdVjVk
+712d0000 vadd.q                 VdVjVk
+712d8000 vsub.q                 VdVjVk
+712e0000 vsigncov.b             VdVjVk
+712e8000 vsigncov.h             VdVjVk
+712f0000 vsigncov.w             VdVjVk
+712f8000 vsigncov.d             VdVjVk
+71308000 vfadd.s                VdVjVk
+71310000 vfadd.d                VdVjVk
+71328000 vfsub.s                VdVjVk
+71330000 vfsub.d                VdVjVk
+71388000 vfmul.s                VdVjVk
+71390000 vfmul.d                VdVjVk
+713a8000 vfdiv.s                VdVjVk
+713b0000 vfdiv.d                VdVjVk
+713c8000 vfmax.s                VdVjVk
+713d0000 vfmax.d                VdVjVk
+713e8000 vfmin.s                VdVjVk
+713f0000 vfmin.d                VdVjVk
+71408000 vfmaxa.s               VdVjVk
+71410000 vfmaxa.d               VdVjVk
+71428000 vfmina.s               VdVjVk
+71430000 vfmina.d               VdVjVk
+71460000 vfcvt.h.s              VdVjVk
+71468000 vfcvt.s.d              VdVjVk
+71480000 vffint.s.l             VdVjVk
+71498000 vftint.w.d             VdVjVk
+714a0000 vftintrm.w.d           VdVjVk
+714a8000 vftintrp.w.d           VdVjVk
+714b0000 vftintrz.w.d           VdVjVk
+714b8000 vftintrne.w.d          VdVjVk
+717a8000 vshuf.h                VdVjVk
+717b0000 vshuf.w                VdVjVk
+717b8000 vshuf.d                VdVjVk
 72800000 vseqi.b                VdVjSk5         @qemu
 72808000 vseqi.h                VdVjSk5         @qemu
 72810000 vseqi.w                VdVjSk5         @qemu
@@ -461,8 +461,8 @@
 728c8000 vsubi.hu               VdVjUk5         @qemu
 728d0000 vsubi.wu               VdVjUk5         @qemu
 728d8000 vsubi.du               VdVjUk5         @qemu
-728e0000 vbsll.v                VdVjUk5         @qemu
-728e8000 vbsrl.v                VdVjUk5         @qemu
+728e0000 vbsll.v                VdVjUk5
+728e8000 vbsrl.v                VdVjUk5
 72900000 vmaxi.b                VdVjSk5         @qemu
 72908000 vmaxi.h                VdVjSk5         @qemu
 72910000 vmaxi.w                VdVjSk5         @qemu
@@ -479,106 +479,106 @@
 72968000 vmini.hu               VdVjUk5         @qemu
 72970000 vmini.wu               VdVjUk5         @qemu
 72978000 vmini.du               VdVjUk5         @qemu
-729a0000 vfrstpi.b              VdVjUk5         @qemu
-729a8000 vfrstpi.h              VdVjUk5         @qemu
-729c0000 vclo.b                 VdVj            @qemu
-729c0400 vclo.h                 VdVj            @qemu
-729c0800 vclo.w                 VdVj            @qemu
-729c0c00 vclo.d                 VdVj            @qemu
-729c1000 vclz.b                 VdVj            @qemu
-729c1400 vclz.h                 VdVj            @qemu
-729c1800 vclz.w                 VdVj            @qemu
-729c1c00 vclz.d                 VdVj            @qemu
-729c2000 vpcnt.b                VdVj            @qemu
-729c2400 vpcnt.h                VdVj            @qemu
-729c2800 vpcnt.w                VdVj            @qemu
-729c2c00 vpcnt.d                VdVj            @qemu
+729a0000 vfrstpi.b              VdVjUk5
+729a8000 vfrstpi.h              VdVjUk5
+729c0000 vclo.b                 VdVj
+729c0400 vclo.h                 VdVj
+729c0800 vclo.w                 VdVj
+729c0c00 vclo.d                 VdVj
+729c1000 vclz.b                 VdVj
+729c1400 vclz.h                 VdVj
+729c1800 vclz.w                 VdVj
+729c1c00 vclz.d                 VdVj
+729c2000 vpcnt.b                VdVj
+729c2400 vpcnt.h                VdVj
+729c2800 vpcnt.w                VdVj
+729c2c00 vpcnt.d                VdVj
 729c3000 vneg.b                 VdVj            @qemu
 729c3400 vneg.h                 VdVj            @qemu
 729c3800 vneg.w                 VdVj            @qemu
 729c3c00 vneg.d                 VdVj            @qemu
-729c4000 vmskltz.b              VdVj            @qemu
-729c4400 vmskltz.h              VdVj            @qemu
-729c4800 vmskltz.w              VdVj            @qemu
-729c4c00 vmskltz.d              VdVj            @qemu
-729c5000 vmskgez.b              VdVj            @qemu
-729c6000 vmsknz.b               VdVj            @qemu
-729c9800 vseteqz.v              CdVj            @qemu
-729c9c00 vsetnez.v              CdVj            @qemu
-729ca000 vsetanyeqz.b           CdVj            @qemu
-729ca400 vsetanyeqz.h           CdVj            @qemu
-729ca800 vsetanyeqz.w           CdVj            @qemu
-729cac00 vsetanyeqz.d           CdVj            @qemu
-729cb000 vsetallnez.b           CdVj            @qemu
-729cb400 vsetallnez.h           CdVj            @qemu
-729cb800 vsetallnez.w           CdVj            @qemu
-729cbc00 vsetallnez.d           CdVj            @qemu
-729cc400 vflogb.s               VdVj            @qemu
-729cc800 vflogb.d               VdVj            @qemu
-729cd400 vfclass.s              VdVj            @qemu
-729cd800 vfclass.d              VdVj            @qemu
-729ce400 vfsqrt.s               VdVj            @qemu
-729ce800 vfsqrt.d               VdVj            @qemu
-729cf400 vfrecip.s              VdVj            @qemu
-729cf800 vfrecip.d              VdVj            @qemu
-729d0400 vfrsqrt.s              VdVj            @qemu
-729d0800 vfrsqrt.d              VdVj            @qemu
+729c4000 vmskltz.b              VdVj
+729c4400 vmskltz.h              VdVj
+729c4800 vmskltz.w              VdVj
+729c4c00 vmskltz.d              VdVj
+729c5000 vmskgez.b              VdVj
+729c6000 vmsknz.b               VdVj
+729c9800 vseteqz.v              CdVj
+729c9c00 vsetnez.v              CdVj
+729ca000 vsetanyeqz.b           CdVj
+729ca400 vsetanyeqz.h           CdVj
+729ca800 vsetanyeqz.w           CdVj
+729cac00 vsetanyeqz.d           CdVj
+729cb000 vsetallnez.b           CdVj
+729cb400 vsetallnez.h           CdVj
+729cb800 vsetallnez.w           CdVj
+729cbc00 vsetallnez.d           CdVj
+729cc400 vflogb.s               VdVj
+729cc800 vflogb.d               VdVj
+729cd400 vfclass.s              VdVj
+729cd800 vfclass.d              VdVj
+729ce400 vfsqrt.s               VdVj
+729ce800 vfsqrt.d               VdVj
+729cf400 vfrecip.s              VdVj
+729cf800 vfrecip.d              VdVj
+729d0400 vfrsqrt.s              VdVj
+729d0800 vfrsqrt.d              VdVj
 729d1400 vfrecipe.s             VdVj            @rev=1p10
 729d1800 vfrecipe.d             VdVj            @rev=1p10
 729d2400 vfrsqrte.s             VdVj            @rev=1p10
 729d2800 vfrsqrte.d             VdVj            @rev=1p10
-729d3400 vfrint.s               VdVj            @qemu
-729d3800 vfrint.d               VdVj            @qemu
-729d4400 vfrintrm.s             VdVj            @qemu
-729d4800 vfrintrm.d             VdVj            @qemu
-729d5400 vfrintrp.s             VdVj            @qemu
-729d5800 vfrintrp.d             VdVj            @qemu
-729d6400 vfrintrz.s             VdVj            @qemu
-729d6800 vfrintrz.d             VdVj            @qemu
-729d7400 vfrintrne.s            VdVj            @qemu
-729d7800 vfrintrne.d            VdVj            @qemu
-729de800 vfcvtl.s.h             VdVj            @qemu
-729dec00 vfcvth.s.h             VdVj            @qemu
-729df000 vfcvtl.d.s             VdVj            @qemu
-729df400 vfcvth.d.s             VdVj            @qemu
-729e0000 vffint.s.w             VdVj            @qemu
-729e0400 vffint.s.wu            VdVj            @qemu
-729e0800 vffint.d.l             VdVj            @qemu
-729e0c00 vffint.d.lu            VdVj            @qemu
-729e1000 vffintl.d.w            VdVj            @qemu
-729e1400 vffinth.d.w            VdVj            @qemu
-729e3000 vftint.w.s             VdVj            @qemu
-729e3400 vftint.l.d             VdVj            @qemu
-729e3800 vftintrm.w.s           VdVj            @qemu
-729e3c00 vftintrm.l.d           VdVj            @qemu
-729e4000 vftintrp.w.s           VdVj            @qemu
-729e4400 vftintrp.l.d           VdVj            @qemu
-729e4800 vftintrz.w.s           VdVj            @qemu
-729e4c00 vftintrz.l.d           VdVj            @qemu
-729e5000 vftintrne.w.s          VdVj            @qemu
-729e5400 vftintrne.l.d          VdVj            @qemu
-729e5800 vftint.wu.s            VdVj            @qemu
-729e5c00 vftint.lu.d            VdVj            @qemu
-729e7000 vftintrz.wu.s          VdVj            @qemu
-729e7400 vftintrz.lu.d          VdVj            @qemu
-729e8000 vftintl.l.s            VdVj            @qemu
-729e8400 vftinth.l.s            VdVj            @qemu
-729e8800 vftintrml.l.s          VdVj            @qemu
-729e8c00 vftintrmh.l.s          VdVj            @qemu
-729e9000 vftintrpl.l.s          VdVj            @qemu
-729e9400 vftintrph.l.s          VdVj            @qemu
-729e9800 vftintrzl.l.s          VdVj            @qemu
-729e9c00 vftintrzh.l.s          VdVj            @qemu
-729ea000 vftintrnel.l.s         VdVj            @qemu
-729ea400 vftintrneh.l.s         VdVj            @qemu
-729ee000 vexth.h.b              VdVj            @qemu
-729ee400 vexth.w.h              VdVj            @qemu
-729ee800 vexth.d.w              VdVj            @qemu
-729eec00 vexth.q.d              VdVj            @qemu
-729ef000 vexth.hu.bu            VdVj            @qemu
-729ef400 vexth.wu.hu            VdVj            @qemu
-729ef800 vexth.du.wu            VdVj            @qemu
-729efc00 vexth.qu.du            VdVj            @qemu
+729d3400 vfrint.s               VdVj
+729d3800 vfrint.d               VdVj
+729d4400 vfrintrm.s             VdVj
+729d4800 vfrintrm.d             VdVj
+729d5400 vfrintrp.s             VdVj
+729d5800 vfrintrp.d             VdVj
+729d6400 vfrintrz.s             VdVj
+729d6800 vfrintrz.d             VdVj
+729d7400 vfrintrne.s            VdVj
+729d7800 vfrintrne.d            VdVj
+729de800 vfcvtl.s.h             VdVj
+729dec00 vfcvth.s.h             VdVj
+729df000 vfcvtl.d.s             VdVj
+729df400 vfcvth.d.s             VdVj
+729e0000 vffint.s.w             VdVj
+729e0400 vffint.s.wu            VdVj
+729e0800 vffint.d.l             VdVj
+729e0c00 vffint.d.lu            VdVj
+729e1000 vffintl.d.w            VdVj
+729e1400 vffinth.d.w            VdVj
+729e3000 vftint.w.s             VdVj
+729e3400 vftint.l.d             VdVj
+729e3800 vftintrm.w.s           VdVj
+729e3c00 vftintrm.l.d           VdVj
+729e4000 vftintrp.w.s           VdVj
+729e4400 vftintrp.l.d           VdVj
+729e4800 vftintrz.w.s           VdVj
+729e4c00 vftintrz.l.d           VdVj
+729e5000 vftintrne.w.s          VdVj
+729e5400 vftintrne.l.d          VdVj
+729e5800 vftint.wu.s            VdVj
+729e5c00 vftint.lu.d            VdVj
+729e7000 vftintrz.wu.s          VdVj
+729e7400 vftintrz.lu.d          VdVj
+729e8000 vftintl.l.s            VdVj
+729e8400 vftinth.l.s            VdVj
+729e8800 vftintrml.l.s          VdVj
+729e8c00 vftintrmh.l.s          VdVj
+729e9000 vftintrpl.l.s          VdVj
+729e9400 vftintrph.l.s          VdVj
+729e9800 vftintrzl.l.s          VdVj
+729e9c00 vftintrzh.l.s          VdVj
+729ea000 vftintrnel.l.s         VdVj
+729ea400 vftintrneh.l.s         VdVj
+729ee000 vexth.h.b              VdVj
+729ee400 vexth.w.h              VdVj
+729ee800 vexth.d.w              VdVj
+729eec00 vexth.q.d              VdVj
+729ef000 vexth.hu.bu            VdVj
+729ef400 vexth.wu.hu            VdVj
+729ef800 vexth.du.wu            VdVj
+729efc00 vexth.qu.du            VdVj
 729f0000 vreplgr2vr.b           VdJ             @qemu
 729f0400 vreplgr2vr.h           VdJ             @qemu
 729f0800 vreplgr2vr.w           VdJ             @qemu
@@ -587,14 +587,14 @@
 72a04000 vrotri.h               VdVjUk4         @qemu
 72a08000 vrotri.w               VdVjUk5         @qemu
 72a10000 vrotri.d               VdVjUk6         @qemu
-72a42000 vsrlri.b               VdVjUk3         @qemu
-72a44000 vsrlri.h               VdVjUk4         @qemu
-72a48000 vsrlri.w               VdVjUk5         @qemu
-72a50000 vsrlri.d               VdVjUk6         @qemu
-72a82000 vsrari.b               VdVjUk3         @qemu
-72a84000 vsrari.h               VdVjUk4         @qemu
-72a88000 vsrari.w               VdVjUk5         @qemu
-72a90000 vsrari.d               VdVjUk6         @qemu
+72a42000 vsrlri.b               VdVjUk3
+72a44000 vsrlri.h               VdVjUk4
+72a48000 vsrlri.w               VdVjUk5
+72a50000 vsrlri.d               VdVjUk6
+72a82000 vsrari.b               VdVjUk3
+72a84000 vsrari.h               VdVjUk4
+72a88000 vsrari.w               VdVjUk5
+72a90000 vsrari.d               VdVjUk6
 72eb8000 vinsgr2vr.b            VdJUk4          @qemu
 72ebc000 vinsgr2vr.h            VdJUk3          @qemu
 72ebe000 vinsgr2vr.w            VdJUk2          @qemu
@@ -611,14 +611,14 @@
 72f7c000 vreplvei.h             VdVjUk3         @qemu
 72f7e000 vreplvei.w             VdVjUk2         @qemu
 72f7f000 vreplvei.d             VdVjUk1         @qemu
-73082000 vsllwil.h.b            VdVjUk3         @qemu
-73084000 vsllwil.w.h            VdVjUk4         @qemu
-73088000 vsllwil.d.w            VdVjUk5         @qemu
-73090000 vextl.q.d              VdVj            @qemu
-730c2000 vsllwil.hu.bu          VdVjUk3         @qemu
-730c4000 vsllwil.wu.hu          VdVjUk4         @qemu
-730c8000 vsllwil.du.wu          VdVjUk5         @qemu
-730d0000 vextl.qu.du            VdVj            @qemu
+73082000 vsllwil.h.b            VdVjUk3
+73084000 vsllwil.w.h            VdVjUk4
+73088000 vsllwil.d.w            VdVjUk5
+73090000 vextl.q.d              VdVj
+730c2000 vsllwil.hu.bu          VdVjUk3
+730c4000 vsllwil.wu.hu          VdVjUk4
+730c8000 vsllwil.du.wu          VdVjUk5
+730d0000 vextl.qu.du            VdVj
 73102000 vbitclri.b             VdVjUk3         @qemu
 73104000 vbitclri.h             VdVjUk4         @qemu
 73108000 vbitclri.w             VdVjUk5         @qemu
@@ -631,14 +631,14 @@
 73184000 vbitrevi.h             VdVjUk4         @qemu
 73188000 vbitrevi.w             VdVjUk5         @qemu
 73190000 vbitrevi.d             VdVjUk6         @qemu
-73242000 vsat.b                 VdVjUk3         @qemu
-73244000 vsat.h                 VdVjUk4         @qemu
-73248000 vsat.w                 VdVjUk5         @qemu
-73250000 vsat.d                 VdVjUk6         @qemu
-73282000 vsat.bu                VdVjUk3         @qemu
-73284000 vsat.hu                VdVjUk4         @qemu
-73288000 vsat.wu                VdVjUk5         @qemu
-73290000 vsat.du                VdVjUk6         @qemu
+73242000 vsat.b                 VdVjUk3
+73244000 vsat.h                 VdVjUk4
+73248000 vsat.w                 VdVjUk5
+73250000 vsat.d                 VdVjUk6
+73282000 vsat.bu                VdVjUk3
+73284000 vsat.hu                VdVjUk4
+73288000 vsat.wu                VdVjUk5
+73290000 vsat.du                VdVjUk6
 732c2000 vslli.b                VdVjUk3         @qemu
 732c4000 vslli.h                VdVjUk4         @qemu
 732c8000 vslli.w                VdVjUk5         @qemu
@@ -651,66 +651,66 @@
 73344000 vsrai.h                VdVjUk4         @qemu
 73348000 vsrai.w                VdVjUk5         @qemu
 73350000 vsrai.d                VdVjUk6         @qemu
-73404000 vsrlni.b.h             VdVjUk4         @qemu
-73408000 vsrlni.h.w             VdVjUk5         @qemu
-73410000 vsrlni.w.d             VdVjUk6         @qemu
-73420000 vsrlni.d.q             VdVjUk7         @qemu
-73444000 vsrlrni.b.h            VdVjUk4         @qemu
-73448000 vsrlrni.h.w            VdVjUk5         @qemu
-73450000 vsrlrni.w.d            VdVjUk6         @qemu
-73460000 vsrlrni.d.q            VdVjUk7         @qemu
-73484000 vssrlni.b.h            VdVjUk4         @qemu
-73488000 vssrlni.h.w            VdVjUk5         @qemu
-73490000 vssrlni.w.d            VdVjUk6         @qemu
-734a0000 vssrlni.d.q            VdVjUk7         @qemu
-734c4000 vssrlni.bu.h           VdVjUk4         @qemu
-734c8000 vssrlni.hu.w           VdVjUk5         @qemu
-734d0000 vssrlni.wu.d           VdVjUk6         @qemu
-734e0000 vssrlni.du.q           VdVjUk7         @qemu
-73504000 vssrlrni.b.h           VdVjUk4         @qemu
-73508000 vssrlrni.h.w           VdVjUk5         @qemu
-73510000 vssrlrni.w.d           VdVjUk6         @qemu
-73520000 vssrlrni.d.q           VdVjUk7         @qemu
-73544000 vssrlrni.bu.h          VdVjUk4         @qemu
-73548000 vssrlrni.hu.w          VdVjUk5         @qemu
-73550000 vssrlrni.wu.d          VdVjUk6         @qemu
-73560000 vssrlrni.du.q          VdVjUk7         @qemu
-73584000 vsrani.b.h             VdVjUk4         @qemu
-73588000 vsrani.h.w             VdVjUk5         @qemu
-73590000 vsrani.w.d             VdVjUk6         @qemu
-735a0000 vsrani.d.q             VdVjUk7         @qemu
-735c4000 vsrarni.b.h            VdVjUk4         @qemu
-735c8000 vsrarni.h.w            VdVjUk5         @qemu
-735d0000 vsrarni.w.d            VdVjUk6         @qemu
-735e0000 vsrarni.d.q            VdVjUk7         @qemu
-73604000 vssrani.b.h            VdVjUk4         @qemu
-73608000 vssrani.h.w            VdVjUk5         @qemu
-73610000 vssrani.w.d            VdVjUk6         @qemu
-73620000 vssrani.d.q            VdVjUk7         @qemu
-73644000 vssrani.bu.h           VdVjUk4         @qemu
-73648000 vssrani.hu.w           VdVjUk5         @qemu
-73650000 vssrani.wu.d           VdVjUk6         @qemu
-73660000 vssrani.du.q           VdVjUk7         @qemu
-73684000 vssrarni.b.h           VdVjUk4         @qemu
-73688000 vssrarni.h.w           VdVjUk5         @qemu
-73690000 vssrarni.w.d           VdVjUk6         @qemu
-736a0000 vssrarni.d.q           VdVjUk7         @qemu
-736c4000 vssrarni.bu.h          VdVjUk4         @qemu
-736c8000 vssrarni.hu.w          VdVjUk5         @qemu
-736d0000 vssrarni.wu.d          VdVjUk6         @qemu
-736e0000 vssrarni.du.q          VdVjUk7         @qemu
-73800000 vextrins.d             VdVjUk8         @qemu
-73840000 vextrins.w             VdVjUk8         @qemu
-73880000 vextrins.h             VdVjUk8         @qemu
-738c0000 vextrins.b             VdVjUk8         @qemu
-73900000 vshuf4i.b              VdVjUk8         @qemu
-73940000 vshuf4i.h              VdVjUk8         @qemu
-73980000 vshuf4i.w              VdVjUk8         @qemu
-739c0000 vshuf4i.d              VdVjUk8         @qemu
+73404000 vsrlni.b.h             VdVjUk4
+73408000 vsrlni.h.w             VdVjUk5
+73410000 vsrlni.w.d             VdVjUk6
+73420000 vsrlni.d.q             VdVjUk7
+73444000 vsrlrni.b.h            VdVjUk4
+73448000 vsrlrni.h.w            VdVjUk5
+73450000 vsrlrni.w.d            VdVjUk6
+73460000 vsrlrni.d.q            VdVjUk7
+73484000 vssrlni.b.h            VdVjUk4
+73488000 vssrlni.h.w            VdVjUk5
+73490000 vssrlni.w.d            VdVjUk6
+734a0000 vssrlni.d.q            VdVjUk7
+734c4000 vssrlni.bu.h           VdVjUk4
+734c8000 vssrlni.hu.w           VdVjUk5
+734d0000 vssrlni.wu.d           VdVjUk6
+734e0000 vssrlni.du.q           VdVjUk7
+73504000 vssrlrni.b.h           VdVjUk4
+73508000 vssrlrni.h.w           VdVjUk5
+73510000 vssrlrni.w.d           VdVjUk6
+73520000 vssrlrni.d.q           VdVjUk7
+73544000 vssrlrni.bu.h          VdVjUk4
+73548000 vssrlrni.hu.w          VdVjUk5
+73550000 vssrlrni.wu.d          VdVjUk6
+73560000 vssrlrni.du.q          VdVjUk7
+73584000 vsrani.b.h             VdVjUk4
+73588000 vsrani.h.w             VdVjUk5
+73590000 vsrani.w.d             VdVjUk6
+735a0000 vsrani.d.q             VdVjUk7
+735c4000 vsrarni.b.h            VdVjUk4
+735c8000 vsrarni.h.w            VdVjUk5
+735d0000 vsrarni.w.d            VdVjUk6
+735e0000 vsrarni.d.q            VdVjUk7
+73604000 vssrani.b.h            VdVjUk4
+73608000 vssrani.h.w            VdVjUk5
+73610000 vssrani.w.d            VdVjUk6
+73620000 vssrani.d.q            VdVjUk7
+73644000 vssrani.bu.h           VdVjUk4
+73648000 vssrani.hu.w           VdVjUk5
+73650000 vssrani.wu.d           VdVjUk6
+73660000 vssrani.du.q           VdVjUk7
+73684000 vssrarni.b.h           VdVjUk4
+73688000 vssrarni.h.w           VdVjUk5
+73690000 vssrarni.w.d           VdVjUk6
+736a0000 vssrarni.d.q           VdVjUk7
+736c4000 vssrarni.bu.h          VdVjUk4
+736c8000 vssrarni.hu.w          VdVjUk5
+736d0000 vssrarni.wu.d          VdVjUk6
+736e0000 vssrarni.du.q          VdVjUk7
+73800000 vextrins.d             VdVjUk8
+73840000 vextrins.w             VdVjUk8
+73880000 vextrins.h             VdVjUk8
+738c0000 vextrins.b             VdVjUk8
+73900000 vshuf4i.b              VdVjUk8
+73940000 vshuf4i.h              VdVjUk8
+73980000 vshuf4i.w              VdVjUk8
+739c0000 vshuf4i.d              VdVjUk8
 73c40000 vbitseli.b             VdVjUk8         @qemu
 73d00000 vandi.b                VdVjUk8         @qemu
 73d40000 vori.b                 VdVjUk8         @qemu
 73d80000 vxori.b                VdVjUk8         @qemu
 73dc0000 vnori.b                VdVjUk8         @qemu
 73e00000 vldi                   VdSj13          @qemu
-73e40000 vpermi.w               VdVjUk8         @qemu
+73e40000 vpermi.w               VdVjUk8

--- a/scripts/go/genqemutcgdefs/main.go
+++ b/scripts/go/genqemutcgdefs/main.go
@@ -365,14 +365,14 @@ func emitFmtEncoderFn(ectx *common.EmitterCtx, f *common.InsnFormat) {
 
 		switch a.Kind {
 		case common.ArgKindIntReg,
-			common.ArgKindFPReg,
 			common.ArgKindFCCReg,
 			common.ArgKindScratchReg:
 			// 0 <= x <= max
 			max := (1 << a.TotalWidth()) - 1
 			ectx.Emit("%s >= 0 && %s <= 0x%x", varName, varName, max)
 
-		case common.ArgKindVReg,
+		case common.ArgKindFPReg,
+			common.ArgKindVReg,
 			common.ArgKindXReg:
 			// 32 <= x <= 32 + max
 			max := (1 << a.TotalWidth()) - 1
@@ -409,7 +409,8 @@ func emitFmtEncoderFn(ectx *common.EmitterCtx, f *common.InsnFormat) {
 			} else {
 				// and pass through everything else
 				switch a.Kind {
-				case common.ArgKindVReg,
+				case common.ArgKindFPReg,
+					common.ArgKindVReg,
 					common.ArgKindXReg:
 					// recover vector register index
 					mask := (1 << a.TotalWidth()) - 1


### PR DESCRIPTION
Floating point registers are 32 <= x <= 63, just like vector registers.
Unmark LSX instructions that are not not used (or usable) in QEMU.
Mark LASX instructions corresponding to the LSX instructions.