### PR TITLE
Annotate LA32R instructions

### DIFF
--- a/la-atomics-32.txt
+++ b/la-atomics-32.txt
@@ -1,5 +1,5 @@
-20000000 ll.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary
-21000000 sc.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary
+20000000 ll.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @la32r @primary
+21000000 sc.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @la32r @primary
 38578000 llacq.w                DJ              @rev=1p10
 38578400 screl.w                DJ              @rev=1p10
 38580000 amcas.b                DJK             @orig_fmt=DKJ @rev=1p10

--- a/la-base-32.txt
+++ b/la-base-32.txt
@@ -1,53 +1,53 @@
 00005800 sext.h                 DJ              @orig_name=ext.w.h @la32 @qemu
 00005c00 sext.b                 DJ              @orig_name=ext.w.b @la32 @qemu
-00006000 rdtimel.w              DJ              @la32 @primary
-00006400 rdtimeh.w              DJ              @la32 @primary
+00006000 rdtimel.w              DJ              @la32 @la32r @primary
+00006400 rdtimeh.w              DJ              @la32 @la32r @primary
 00006c00 cpucfg                 DJ              @la32
-00100000 add.w                  DJK             @la32 @primary @qemu
-00110000 sub.w                  DJK             @la32 @primary @qemu
-00120000 slt                    DJK             @la32 @primary @qemu
+00100000 add.w                  DJK             @la32 @la32r @primary @qemu
+00110000 sub.w                  DJK             @la32 @la32r @primary @qemu
+00120000 slt                    DJK             @la32 @la32r @primary @qemu
 00128000 sltu                   DJK             @la32 @primary @qemu
 00130000 maskeqz                DJK             @la32 @qemu
 00138000 masknez                DJK             @la32 @qemu
-00140000 nor                    DJK             @la32 @primary @qemu
-00148000 and                    DJK             @la32 @primary @qemu
-00150000 or                     DJK             @la32 @primary @qemu
-00158000 xor                    DJK             @la32 @primary @qemu
+00140000 nor                    DJK             @la32 @la32r @primary @qemu
+00148000 and                    DJK             @la32 @la32r @primary @qemu
+00150000 or                     DJK             @la32 @la32r @primary @qemu
+00158000 xor                    DJK             @la32 @la32r @primary @qemu
 00160000 orn                    DJK             @la32 @primary @qemu
 00168000 andn                   DJK             @la32 @primary @qemu
-00170000 sll.w                  DJK             @la32 @primary @qemu
-00178000 srl.w                  DJK             @la32 @primary @qemu
-00180000 sra.w                  DJK             @la32 @primary @qemu
+00170000 sll.w                  DJK             @la32 @la32r @primary @qemu
+00178000 srl.w                  DJK             @la32 @la32r @primary @qemu
+00180000 sra.w                  DJK             @la32 @la32r @primary @qemu
 001b0000 rotr.w                 DJK             @la32 @qemu
-002a0000 break                  Ud15            @la32 @primary
+002a0000 break                  Ud15            @la32 @la32r @primary
 002a8000 dbgcall                Ud15            @orig_name=dbcl
-002b0000 syscall                Ud15            @la32 @primary
-00408000 slli.w                 DJUk5           @la32 @primary @qemu
-00448000 srli.w                 DJUk5           @la32 @primary @qemu
-00488000 srai.w                 DJUk5           @la32 @primary @qemu
-004c8000 rotri.w                DJUk5           @la32 @qemu
-02000000 slti                   DJSk12          @la32 @primary @qemu
-02400000 sltui                  DJSk12          @la32 @primary @qemu
-02800000 addi.w                 DJSk12          @la32 @primary @qemu
-03400000 andi                   DJUk12          @la32 @primary @qemu
-03800000 ori                    DJUk12          @la32 @primary @qemu
-03c00000 xori                   DJUk12          @la32 @primary @qemu
-14000000 lu12i.w                DSj20           @la32 @primary @qemu
+002b0000 syscall                Ud15            @la32 @la32r @primary
+00408000 slli.w                 DJUk5           @la32 @la32r @primary @qemu
+00448000 srli.w                 DJUk5           @la32 @la32r @primary @qemu
+00488000 srai.w                 DJUk5           @la32 @la32r @primary @qemu
+004c8000 rotri.w                DJUk5           @la32 @la32r @qemu
+02000000 slti                   DJSk12          @la32 @la32r @primary @qemu
+02400000 sltui                  DJSk12          @la32 @la32r @primary @qemu
+02800000 addi.w                 DJSk12          @la32 @la32r @primary @qemu
+03400000 andi                   DJUk12          @la32 @la32r @primary @qemu
+03800000 ori                    DJUk12          @la32 @la32r @primary @qemu
+03c00000 xori                   DJUk12          @la32 @la32r @primary @qemu
+14000000 lu12i.w                DSj20           @la32 @la32r @primary @qemu
 18000000 pcaddu2i               DSj20           @orig_name=pcaddi @la32 @primary @qemu
 1a000000 pcalau12i              DSj20           @la32 @qemu
-1c000000 pcaddu12i              DSj20           @la32 @primary @qemu
+1c000000 pcaddu12i              DSj20           @la32 @la32r @primary @qemu
 1e000000 pcaddu18i              DSj20           @qemu
 24000000 ldox4.w                DJSk14          @orig_name=ldptr.w @orig_fmt=DJSk14ps2
 25000000 stox4.w                DJSk14          @orig_name=stptr.w @orig_fmt=DJSk14ps2
-28000000 ld.b                   DJSk12          @la32 @primary @qemu
-28400000 ld.h                   DJSk12          @la32 @primary @qemu
-28800000 ld.w                   DJSk12          @la32 @primary @qemu
-29000000 st.b                   DJSk12          @la32 @primary @qemu
-29400000 st.h                   DJSk12          @la32 @primary @qemu
-29800000 st.w                   DJSk12          @la32 @primary @qemu
-2a000000 ld.bu                  DJSk12          @la32 @primary @qemu
-2a400000 ld.hu                  DJSk12          @la32 @primary @qemu
-2ac00000 preld                  JUd5Sk12        @orig_fmt=Ud5JSk12 @la32 @primary
+28000000 ld.b                   DJSk12          @la32 @la32r @primary @qemu
+28400000 ld.h                   DJSk12          @la32 @la32r @primary @qemu
+28800000 ld.w                   DJSk12          @la32 @la32r @primary @qemu
+29000000 st.b                   DJSk12          @la32 @la32r @primary @qemu
+29400000 st.h                   DJSk12          @la32 @la32r @primary @qemu
+29800000 st.w                   DJSk12          @la32 @la32r @primary @qemu
+2a000000 ld.bu                  DJSk12          @la32 @la32r @primary @qemu
+2a400000 ld.hu                  DJSk12          @la32 @la32r @primary @qemu
+2ac00000 preld                  JUd5Sk12        @orig_fmt=Ud5JSk12 @la32 @la32r @primary
 38000000 ldx.b                  DJK             @qemu
 38040000 ldx.h                  DJK             @qemu
 38080000 ldx.w                  DJK             @qemu
@@ -57,16 +57,16 @@
 38200000 ldx.bu                 DJK             @qemu
 38240000 ldx.hu                 DJK             @qemu
 382c0000 preldx                 JKUd5           @orig_fmt=Ud5JK
-38720000 dbar                   Ud15            @la32 @primary @qemu
-38728000 ibar                   Ud15            @la32 @primary
+38720000 dbar                   Ud15            @la32 @la32r @primary @qemu
+38728000 ibar                   Ud15            @la32 @la32r @primary
 40000000 beqz                   JSd5k16         @orig_fmt=JSd5k16ps2 @la32
 44000000 bnez                   JSd5k16         @orig_fmt=JSd5k16ps2 @la32
-4c000000 jirl                   DJSk16          @orig_fmt=DJSk16ps2 @la32 @primary @qemu
-50000000 b                      Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @primary @qemu
-54000000 bl                     Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @primary @qemu
-58000000 beq                    DJSk16          @orig_fmt=JDSk16ps2 @la32 @primary @qemu
-5c000000 bne                    DJSk16          @orig_fmt=JDSk16ps2 @la32 @primary @qemu
-60000000 bgt                    DJSk16          @orig_name=blt @orig_fmt=JDSk16ps2 @la32 @primary @qemu
-64000000 ble                    DJSk16          @orig_name=bge @orig_fmt=JDSk16ps2 @la32 @primary @qemu
-68000000 bgtu                   DJSk16          @orig_name=bltu @orig_fmt=JDSk16ps2 @la32 @primary @qemu
-6c000000 bleu                   DJSk16          @orig_name=bgeu @orig_fmt=JDSk16ps2 @la32 @primary @qemu
+4c000000 jirl                   DJSk16          @orig_fmt=DJSk16ps2 @la32 @la32r @primary @qemu
+50000000 b                      Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @la32r @primary @qemu
+54000000 bl                     Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @la32r @primary @qemu
+58000000 beq                    DJSk16          @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu
+5c000000 bne                    DJSk16          @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu
+60000000 bgt                    DJSk16          @orig_name=blt @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu
+64000000 ble                    DJSk16          @orig_name=bge @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu
+68000000 bgtu                   DJSk16          @orig_name=bltu @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu
+6c000000 bleu                   DJSk16          @orig_name=bgeu @orig_fmt=JDSk16ps2 @la32 @la32r @primary @qemu

--- a/la-fp-d.txt
+++ b/la-fp-d.txt
@@ -1,67 +1,67 @@
-01010000 fadd.d                 FdFjFk
-01030000 fsub.d                 FdFjFk
-01050000 fmul.d                 FdFjFk
-01070000 fdiv.d                 FdFjFk
-01090000 fmax.d                 FdFjFk
-010b0000 fmin.d                 FdFjFk
-010d0000 fmaxa.d                FdFjFk
-010f0000 fmina.d                FdFjFk
+01010000 fadd.d                 FdFjFk          @la32 @la32r
+01030000 fsub.d                 FdFjFk          @la32 @la32r
+01050000 fmul.d                 FdFjFk          @la32 @la32r
+01070000 fdiv.d                 FdFjFk          @la32 @la32r
+01090000 fmax.d                 FdFjFk          @la32 @la32r
+010b0000 fmin.d                 FdFjFk          @la32 @la32r
+010d0000 fmaxa.d                FdFjFk          @la32 @la32r
+010f0000 fmina.d                FdFjFk          @la32 @la32r
 01110000 fscaleb.d              FdFjFk
-01130000 fcopysign.d            FdFjFk
-01140800 fabs.d                 FdFj
-01141800 fneg.d                 FdFj
+01130000 fcopysign.d            FdFjFk          @la32 @la32r
+01140800 fabs.d                 FdFj            @la32 @la32r
+01141800 fneg.d                 FdFj            @la32 @la32r
 01142800 flogb.d                FdFj
-01143800 fclass.d               FdFj
-01144800 fsqrt.d                FdFj
-01145800 frecip.d               FdFj
-01146800 frsqrt.d               FdFj
+01143800 fclass.d               FdFj            @la32 @la32r
+01144800 fsqrt.d                FdFj            @la32 @la32r
+01145800 frecip.d               FdFj            @la32 @la32r
+01146800 frsqrt.d               FdFj            @la32 @la32r
 01147800 frecipe.d              FdFj            @rev=1p10
 01148800 frsqrte.d              FdFj            @rev=1p10
-01149800 fmov.d                 FdFj            @qemu
+01149800 fmov.d                 FdFj            @la32 @la32r @qemu
 0114a800 movgr2fr.d             FdJ             @qemu
 0114b800 movfr2gr.d             DFj             @qemu
-01191800 fcvt.s.d               FdFj
-01192400 fcvt.d.s               FdFj
-011a0800 ftintrm.w.d            FdFj
-011a2800 ftintrm.l.d            FdFj
-011a4800 ftintrp.w.d            FdFj
-011a6800 ftintrp.l.d            FdFj
-011a8800 ftintrz.w.d            FdFj
-011aa800 ftintrz.l.d            FdFj
-011ac800 ftintrne.w.d           FdFj
-011ae800 ftintrne.l.d           FdFj
-011b0800 ftint.w.d              FdFj
-011b2800 ftint.l.d              FdFj
-011d2000 ffint.d.w              FdFj
-011d2800 ffint.d.l              FdFj
+01191800 fcvt.s.d               FdFj            @la32 @la32r
+01192400 fcvt.d.s               FdFj            @la32 @la32r
+011a0800 ftintrm.w.d            FdFj            @la32 @la32r
+011a2800 ftintrm.l.d            FdFj            @la32
+011a4800 ftintrp.w.d            FdFj            @la32 @la32r
+011a6800 ftintrp.l.d            FdFj            @la32
+011a8800 ftintrz.w.d            FdFj            @la32 @la32r
+011aa800 ftintrz.l.d            FdFj            @la32
+011ac800 ftintrne.w.d           FdFj            @la32 @la32r
+011ae800 ftintrne.l.d           FdFj            @la32
+011b0800 ftint.w.d              FdFj            @la32 @la32r
+011b2800 ftint.l.d              FdFj            @la32
+011d2000 ffint.d.w              FdFj            @la32 @la32r
+011d2800 ffint.d.l              FdFj            @la32
 011e4800 frint.d                FdFj
-08200000 fmadd.d                FdFjFkFa
-08600000 fmsub.d                FdFjFkFa
-08a00000 fnmadd.d               FdFjFkFa
-08e00000 fnmsub.d               FdFjFkFa
-0c200000 fcmp.caf.d             CdFjFk
-0c208000 fcmp.saf.d             CdFjFk
-0c210000 fcmp.clt.d             CdFjFk
-0c218000 fcmp.slt.d             CdFjFk
-0c220000 fcmp.ceq.d             CdFjFk
-0c228000 fcmp.seq.d             CdFjFk
-0c230000 fcmp.cle.d             CdFjFk
-0c238000 fcmp.sle.d             CdFjFk
-0c240000 fcmp.cun.d             CdFjFk
-0c248000 fcmp.sun.d             CdFjFk
-0c250000 fcmp.cult.d            CdFjFk
-0c258000 fcmp.sult.d            CdFjFk
-0c260000 fcmp.cueq.d            CdFjFk
-0c268000 fcmp.sueq.d            CdFjFk
-0c270000 fcmp.cule.d            CdFjFk
-0c278000 fcmp.sule.d            CdFjFk
-0c280000 fcmp.cne.d             CdFjFk
-0c288000 fcmp.sne.d             CdFjFk
-0c2a0000 fcmp.cor.d             CdFjFk
-0c2a8000 fcmp.sor.d             CdFjFk
-0c2c0000 fcmp.cune.d            CdFjFk
-0c2c8000 fcmp.sune.d            CdFjFk
-2b800000 fld.d                  FdJSk12         @qemu
-2bc00000 fst.d                  FdJSk12         @qemu
+08200000 fmadd.d                FdFjFkFa        @la32 @la32r
+08600000 fmsub.d                FdFjFkFa        @la32 @la32r
+08a00000 fnmadd.d               FdFjFkFa        @la32 @la32r
+08e00000 fnmsub.d               FdFjFkFa        @la32 @la32r
+0c200000 fcmp.caf.d             CdFjFk          @la32 @la32r
+0c208000 fcmp.saf.d             CdFjFk          @la32 @la32r
+0c210000 fcmp.clt.d             CdFjFk          @la32 @la32r
+0c218000 fcmp.slt.d             CdFjFk          @la32 @la32r
+0c220000 fcmp.ceq.d             CdFjFk          @la32 @la32r
+0c228000 fcmp.seq.d             CdFjFk          @la32 @la32r
+0c230000 fcmp.cle.d             CdFjFk          @la32 @la32r
+0c238000 fcmp.sle.d             CdFjFk          @la32 @la32r
+0c240000 fcmp.cun.d             CdFjFk          @la32 @la32r
+0c248000 fcmp.sun.d             CdFjFk          @la32 @la32r
+0c250000 fcmp.cult.d            CdFjFk          @la32 @la32r
+0c258000 fcmp.sult.d            CdFjFk          @la32 @la32r
+0c260000 fcmp.cueq.d            CdFjFk          @la32 @la32r
+0c268000 fcmp.sueq.d            CdFjFk          @la32 @la32r
+0c270000 fcmp.cule.d            CdFjFk          @la32 @la32r
+0c278000 fcmp.sule.d            CdFjFk          @la32 @la32r
+0c280000 fcmp.cne.d             CdFjFk          @la32 @la32r
+0c288000 fcmp.sne.d             CdFjFk          @la32 @la32r
+0c2a0000 fcmp.cor.d             CdFjFk          @la32 @la32r
+0c2a8000 fcmp.sor.d             CdFjFk          @la32 @la32r
+0c2c0000 fcmp.cune.d            CdFjFk          @la32 @la32r
+0c2c8000 fcmp.sune.d            CdFjFk          @la32 @la32r
+2b800000 fld.d                  FdJSk12         @la32 @la32r @qemu
+2bc00000 fst.d                  FdJSk12         @la32 @la32r @qemu
 38340000 fldx.d                 FdJK            @qemu
 383c0000 fstx.d                 FdJK            @qemu

--- a/la-fp-s.txt
+++ b/la-fp-s.txt
@@ -1,67 +1,67 @@
-01008000 fadd.s                 FdFjFk
-01028000 fsub.s                 FdFjFk
-01048000 fmul.s                 FdFjFk
-01068000 fdiv.s                 FdFjFk
-01088000 fmax.s                 FdFjFk
-010a8000 fmin.s                 FdFjFk
-010c8000 fmaxa.s                FdFjFk
-010e8000 fmina.s                FdFjFk
+01008000 fadd.s                 FdFjFk          @la32 @la32r
+01028000 fsub.s                 FdFjFk          @la32 @la32r
+01048000 fmul.s                 FdFjFk          @la32 @la32r
+01068000 fdiv.s                 FdFjFk          @la32 @la32r
+01088000 fmax.s                 FdFjFk          @la32 @la32r
+010a8000 fmin.s                 FdFjFk          @la32 @la32r
+010c8000 fmaxa.s                FdFjFk          @la32 @la32r
+010e8000 fmina.s                FdFjFk          @la32 @la32r
 01108000 fscaleb.s              FdFjFk
-01128000 fcopysign.s            FdFjFk
-01140400 fabs.s                 FdFj
-01141400 fneg.s                 FdFj
+01128000 fcopysign.s            FdFjFk          @la32 @la32r
+01140400 fabs.s                 FdFj            @la32 @la32r
+01141400 fneg.s                 FdFj            @la32 @la32r
 01142400 flogb.s                FdFj
-01143400 fclass.s               FdFj
-01144400 fsqrt.s                FdFj
-01145400 frecip.s               FdFj
-01146400 frsqrt.s               FdFj
+01143400 fclass.s               FdFj            @la32 @la32r
+01144400 fsqrt.s                FdFj            @la32 @la32r
+01145400 frecip.s               FdFj            @la32 @la32r
+01146400 frsqrt.s               FdFj            @la32 @la32r
 01147400 frecipe.s              FdFj            @rev=1p10
 01148400 frsqrte.s              FdFj            @rev=1p10
-01149400 fmov.s                 FdFj
-0114a400 movgr2fr.w             FdJ
-0114ac00 movgr2frh.w            FdJ
-0114b400 movfr2gr.s             DFj
-0114bc00 movfrh2gr.s            DFj
-011a0400 ftintrm.w.s            FdFj
-011a2400 ftintrm.l.s            FdFj
-011a4400 ftintrp.w.s            FdFj
-011a6400 ftintrp.l.s            FdFj
-011a8400 ftintrz.w.s            FdFj
-011aa400 ftintrz.l.s            FdFj
-011ac400 ftintrne.w.s           FdFj
-011ae400 ftintrne.l.s           FdFj
-011b0400 ftint.w.s              FdFj
-011b2400 ftint.l.s              FdFj
-011d1000 ffint.s.w              FdFj
-011d1800 ffint.s.l              FdFj
+01149400 fmov.s                 FdFj            @la32 @la32r @qemu
+0114a400 movgr2fr.w             FdJ             @la32 @la32r @qemu
+0114ac00 movgr2frh.w            FdJ             @la32 @la32r
+0114b400 movfr2gr.s             DFj             @la32 @la32r @qemu
+0114bc00 movfrh2gr.s            DFj             @la32 @la32r
+011a0400 ftintrm.w.s            FdFj            @la32 @la32r
+011a2400 ftintrm.l.s            FdFj            @la32
+011a4400 ftintrp.w.s            FdFj            @la32 @la32r
+011a6400 ftintrp.l.s            FdFj            @la32
+011a8400 ftintrz.w.s            FdFj            @la32 @la32r
+011aa400 ftintrz.l.s            FdFj            @la32
+011ac400 ftintrne.w.s           FdFj            @la32 @la32r
+011ae400 ftintrne.l.s           FdFj            @la32
+011b0400 ftint.w.s              FdFj            @la32 @la32r
+011b2400 ftint.l.s              FdFj            @la32
+011d1000 ffint.s.w              FdFj            @la32 @la32r
+011d1800 ffint.s.l              FdFj            @la32
 011e4400 frint.s                FdFj
-08100000 fmadd.s                FdFjFkFa
-08500000 fmsub.s                FdFjFkFa
-08900000 fnmadd.s               FdFjFkFa
-08d00000 fnmsub.s               FdFjFkFa
-0c100000 fcmp.caf.s             CdFjFk
-0c108000 fcmp.saf.s             CdFjFk
-0c110000 fcmp.clt.s             CdFjFk
-0c118000 fcmp.slt.s             CdFjFk
-0c120000 fcmp.ceq.s             CdFjFk
-0c128000 fcmp.seq.s             CdFjFk
-0c130000 fcmp.cle.s             CdFjFk
-0c138000 fcmp.sle.s             CdFjFk
-0c140000 fcmp.cun.s             CdFjFk
-0c148000 fcmp.sun.s             CdFjFk
-0c150000 fcmp.cult.s            CdFjFk
-0c158000 fcmp.sult.s            CdFjFk
-0c160000 fcmp.cueq.s            CdFjFk
-0c168000 fcmp.sueq.s            CdFjFk
-0c170000 fcmp.cule.s            CdFjFk
-0c178000 fcmp.sule.s            CdFjFk
-0c180000 fcmp.cne.s             CdFjFk
-0c188000 fcmp.sne.s             CdFjFk
-0c1a0000 fcmp.cor.s             CdFjFk
-0c1a8000 fcmp.sor.s             CdFjFk
-0c1c0000 fcmp.cune.s            CdFjFk
-0c1c8000 fcmp.sune.s            CdFjFk
-2b000000 fld.s                  FdJSk12         @qemu
-2b400000 fst.s                  FdJSk12         @qemu
+08100000 fmadd.s                FdFjFkFa        @la32 @la32r
+08500000 fmsub.s                FdFjFkFa        @la32 @la32r
+08900000 fnmadd.s               FdFjFkFa        @la32 @la32r
+08d00000 fnmsub.s               FdFjFkFa        @la32 @la32r
+0c100000 fcmp.caf.s             CdFjFk          @la32 @la32r
+0c108000 fcmp.saf.s             CdFjFk          @la32 @la32r
+0c110000 fcmp.clt.s             CdFjFk          @la32 @la32r
+0c118000 fcmp.slt.s             CdFjFk          @la32 @la32r
+0c120000 fcmp.ceq.s             CdFjFk          @la32 @la32r
+0c128000 fcmp.seq.s             CdFjFk          @la32 @la32r
+0c130000 fcmp.cle.s             CdFjFk          @la32 @la32r
+0c138000 fcmp.sle.s             CdFjFk          @la32 @la32r
+0c140000 fcmp.cun.s             CdFjFk          @la32 @la32r
+0c148000 fcmp.sun.s             CdFjFk          @la32 @la32r
+0c150000 fcmp.cult.s            CdFjFk          @la32 @la32r
+0c158000 fcmp.sult.s            CdFjFk          @la32 @la32r
+0c160000 fcmp.cueq.s            CdFjFk          @la32 @la32r
+0c168000 fcmp.sueq.s            CdFjFk          @la32 @la32r
+0c170000 fcmp.cule.s            CdFjFk          @la32 @la32r
+0c178000 fcmp.sule.s            CdFjFk          @la32 @la32r
+0c180000 fcmp.cne.s             CdFjFk          @la32 @la32r
+0c188000 fcmp.sne.s             CdFjFk          @la32 @la32r
+0c1a0000 fcmp.cor.s             CdFjFk          @la32 @la32r
+0c1a8000 fcmp.sor.s             CdFjFk          @la32 @la32r
+0c1c0000 fcmp.cune.s            CdFjFk          @la32 @la32r
+0c1c8000 fcmp.sune.s            CdFjFk          @la32 @la32r
+2b000000 fld.s                  FdJSk12         @la32 @la32r @qemu
+2b400000 fst.s                  FdJSk12         @la32 @la32r @qemu
 38300000 fldx.s                 FdJK            @qemu
 38380000 fstx.s                 FdJK            @qemu

--- a/la-fp.txt
+++ b/la-fp.txt
@@ -1,9 +1,9 @@
-0114c000 fcsrwr                 JUd5            @orig_name=movgr2fcsr @orig_fmt=DJ
-0114c800 fcsrrd                 DUj5            @orig_name=movfcsr2gr @orig_fmt=DJ
-0114d000 movfr2fcc              CdFj            @orig_name=movfr2cf
-0114d400 movfcc2fr              FdCj            @orig_name=movcf2fr
-0114d800 movgr2fcc              CdJ             @orig_name=movgr2cf
-0114dc00 movfcc2gr              DCj             @orig_name=movcf2gr
-0d000000 fsel                   FdFjFkCa
-48000000 bceqz                  CjSd5k16        @orig_fmt=CjSd5k16ps2
-48000100 bcnez                  CjSd5k16        @orig_fmt=CjSd5k16ps2
+0114c000 fcsrwr                 JUd5            @orig_name=movgr2fcsr @orig_fmt=DJ @la32 @la32r
+0114c800 fcsrrd                 DUj5            @orig_name=movfcsr2gr @orig_fmt=DJ @la32 @la32r
+0114d000 movfr2fcc              CdFj            @orig_name=movfr2cf @la32 @la32r
+0114d400 movfcc2fr              FdCj            @orig_name=movcf2fr @la32 @la32r
+0114d800 movgr2fcc              CdJ             @orig_name=movgr2cf @la32 @la32r
+0114dc00 movfcc2gr              DCj             @orig_name=movcf2gr @la32 @la32r
+0d000000 fsel                   FdFjFkCa        @la32 @la32r
+48000000 bceqz                  CjSd5k16        @orig_fmt=CjSd5k16ps2 @la32 @la32r
+48000100 bcnez                  CjSd5k16        @orig_fmt=CjSd5k16ps2 @la32 @la32r

--- a/la-mul-32.txt
+++ b/la-mul-32.txt
@@ -1,7 +1,7 @@
-001c0000 mul.w                  DJK             @la32 @primary @qemu
-001c8000 mulh.w                 DJK             @la32 @primary @qemu
-001d0000 mulh.wu                DJK             @la32 @primary @qemu
-00200000 div.w                  DJK             @la32 @primary @qemu
-00208000 mod.w                  DJK             @la32 @primary @qemu
-00210000 div.wu                 DJK             @la32 @primary @qemu
-00218000 mod.wu                 DJK             @la32 @primary @qemu
+001c0000 mul.w                  DJK             @la32 @la32r @primary @qemu
+001c8000 mulh.w                 DJK             @la32 @la32r @primary @qemu
+001d0000 mulh.wu                DJK             @la32 @la32r @primary @qemu
+00200000 div.w                  DJK             @la32 @la32r @primary @qemu
+00208000 mod.w                  DJK             @la32 @la32r @primary @qemu
+00210000 div.wu                 DJK             @la32 @la32r @primary @qemu
+00218000 mod.wu                 DJK             @la32 @la32r @primary @qemu


### PR DESCRIPTION
Annotate LA32R instructions based on 《龙芯架构 32 位精简版参考手册 V1.03》. LA32 FPU instructions are handled as well.

For the LA32 FPU, we need some further feature set clarification.

To quote《龙芯架构参考手册 卷一：基础架构 V1.10》: "但是 FSCALEB.S/D、FLOGB.S/D、FRINT.S/D、FRECIPE.S/D 和 FRSQRTE.S/D 这 10 条指令仅需在 LA64 架构下实现。"

- There are more Instructions that cannot be implemented in 32-bit mode: `movgr2fr.d`, `movfr2gr.d`, what's the expected behaviour?

- Need confirmation on whether LA32 should include these instructions missing from LA32R: `FTINT{RM/RP/RZ/RNE}.L.{S/D}`.