### PR TITLE
feat: add two undocumented opcodes

### DIFF
--- a/lasx.txt
+++ b/lasx.txt
@@ -482,6 +482,7 @@
 76978000 xvmini.du              XdXjUk5         @qemu
 769a0000 xvfrstpi.b             XdXjUk5
 769a8000 xvfrstpi.h             XdXjUk5
+769b8000 xvmepatmsk.v           XdUj5Uk5
 769c0000 xvclo.b                XdXj
 769c0400 xvclo.h                XdXj
 769c0800 xvclo.w                XdXj

--- a/lsx.txt
+++ b/lsx.txt
@@ -481,6 +481,7 @@
 72978000 vmini.du               VdVjUk5         @qemu
 729a0000 vfrstpi.b              VdVjUk5
 729a8000 vfrstpi.h              VdVjUk5
+729b8000 vmepatmsk.v            VdUj5Uk5
 729c0000 vclo.b                 VdVj
 729c0400 vclo.h                 VdVj
 729c0800 vclo.w                 VdVj


### PR DESCRIPTION
The encodings can be found in https://github.com/lat-opensource/lat/blob/a8e57f34/target/i386/latx/inst_template.json#L10321-L10328 and http://github.com/lat-opensource/lat/blob/a8e57f34/target/i386/latx/inst_template.json#L18164-L18171.