### PR TITLE
Annotate modified registers

### DIFF
--- a/la-atomics-32.txt
+++ b/la-atomics-32.txt
@@ -1,32 +1,32 @@
-20000000 ll.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary
-21000000 sc.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary
-38578000 llacq.w                DJ              @rev=1p10
-38578400 screl.w                DJ              @rev=1p10
-38580000 amcas.b                DJK             @orig_fmt=DKJ @rev=1p10
-38588000 amcas.h                DJK             @orig_fmt=DKJ @rev=1p10
-38590000 amcas.w                DJK             @orig_fmt=DKJ @rev=1p10
-385a0000 amcas_db.b             DJK             @orig_fmt=DKJ @rev=1p10
-385a8000 amcas_db.h             DJK             @orig_fmt=DKJ @rev=1p10
-385b0000 amcas_db.w             DJK             @orig_fmt=DKJ @rev=1p10
-385c0000 amswap.b               DJK             @orig_fmt=DKJ @rev=1p10
-385c8000 amswap.h               DJK             @orig_fmt=DKJ @rev=1p10
-385d0000 amadd.b                DJK             @orig_fmt=DKJ @rev=1p10
-385d8000 amadd.h                DJK             @orig_fmt=DKJ @rev=1p10
-385e0000 amswap_db.b            DJK             @orig_fmt=DKJ @rev=1p10
-385e8000 amswap_db.h            DJK             @orig_fmt=DKJ @rev=1p10
-385f0000 amadd_db.b             DJK             @orig_fmt=DKJ @rev=1p10
-385f8000 amadd_db.h             DJK             @orig_fmt=DKJ @rev=1p10
-38600000 amswap.w               DJK             @orig_fmt=DKJ
-38610000 amadd.w                DJK             @orig_fmt=DKJ
-38620000 amand.w                DJK             @orig_fmt=DKJ
-38630000 amor.w                 DJK             @orig_fmt=DKJ
-38640000 amxor.w                DJK             @orig_fmt=DKJ
-38650000 ammax.w                DJK             @orig_fmt=DKJ
-38660000 ammin.w                DJK             @orig_fmt=DKJ
-38690000 amswap_db.w            DJK             @orig_fmt=DKJ
-386a0000 amadd_db.w             DJK             @orig_fmt=DKJ
-386b0000 amand_db.w             DJK             @orig_fmt=DKJ
-386c0000 amor_db.w              DJK             @orig_fmt=DKJ
-386d0000 amxor_db.w             DJK             @orig_fmt=DKJ
-386e0000 ammax_db.w             DJK             @orig_fmt=DKJ
-386f0000 ammin_db.w             DJK             @orig_fmt=DKJ
+20000000 ll.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary @modify=D
+21000000 sc.w                   DJSk14          @orig_fmt=DJSk14ps2 @la32 @primary @modify=D
+38578000 llacq.w                DJ              @rev=1p10 @modify=D
+38578400 screl.w                DJ              @rev=1p10 @modify=D
+38580000 amcas.b                DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+38588000 amcas.h                DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+38590000 amcas.w                DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+385a0000 amcas_db.b             DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+385a8000 amcas_db.h             DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+385b0000 amcas_db.w             DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+385c0000 amswap.b               DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385c8000 amswap.h               DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385d0000 amadd.b                DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385d8000 amadd.h                DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385e0000 amswap_db.b            DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385e8000 amswap_db.h            DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385f0000 amadd_db.b             DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+385f8000 amadd_db.h             DJK             @orig_fmt=DKJ @rev=1p10 @modify=DK
+38600000 amswap.w               DJK             @orig_fmt=DKJ @modify=DK
+38610000 amadd.w                DJK             @orig_fmt=DKJ @modify=DK
+38620000 amand.w                DJK             @orig_fmt=DKJ @modify=D
+38630000 amor.w                 DJK             @orig_fmt=DKJ @modify=D
+38640000 amxor.w                DJK             @orig_fmt=DKJ @modify=D
+38650000 ammax.w                DJK             @orig_fmt=DKJ @modify=D
+38660000 ammin.w                DJK             @orig_fmt=DKJ @modify=D
+38690000 amswap_db.w            DJK             @orig_fmt=DKJ @modify=DK
+386a0000 amadd_db.w             DJK             @orig_fmt=DKJ @modify=DK
+386b0000 amand_db.w             DJK             @orig_fmt=DKJ @modify=D
+386c0000 amor_db.w              DJK             @orig_fmt=DKJ @modify=D
+386d0000 amxor_db.w             DJK             @orig_fmt=DKJ @modify=D
+386e0000 ammax_db.w             DJK             @orig_fmt=DKJ @modify=D
+386f0000 ammin_db.w             DJK             @orig_fmt=DKJ @modify=D

--- a/la-atomics-64.txt
+++ b/la-atomics-64.txt
@@ -1,29 +1,29 @@
-22000000 ll.d                   DJSk14          @orig_fmt=DJSk14ps2
-23000000 sc.d                   DJSk14          @orig_fmt=DJSk14ps2
-38570000 sc.q                   DJK             @orig_fmt=DKJ @rev=1p10
-38578800 llacq.d                DJ              @rev=1p10
-38578c00 screl.d                DJ              @rev=1p10
-38598000 amcas.d                DJK             @orig_fmt=DKJ @rev=1p10
-385b8000 amcas_db.d             DJK             @orig_fmt=DKJ @rev=1p10
-38608000 amswap.d               DJK             @orig_fmt=DKJ
-38618000 amadd.d                DJK             @orig_fmt=DKJ
-38628000 amand.d                DJK             @orig_fmt=DKJ
-38638000 amor.d                 DJK             @orig_fmt=DKJ
-38648000 amxor.d                DJK             @orig_fmt=DKJ
-38658000 ammax.d                DJK             @orig_fmt=DKJ
-38668000 ammin.d                DJK             @orig_fmt=DKJ
-38670000 ammax.wu               DJK             @orig_fmt=DKJ
-38678000 ammax.du               DJK             @orig_fmt=DKJ
-38680000 ammin.wu               DJK             @orig_fmt=DKJ
-38688000 ammin.du               DJK             @orig_fmt=DKJ
-38698000 amswap_db.d            DJK             @orig_fmt=DKJ
-386a8000 amadd_db.d             DJK             @orig_fmt=DKJ
-386b8000 amand_db.d             DJK             @orig_fmt=DKJ
-386c8000 amor_db.d              DJK             @orig_fmt=DKJ
-386d8000 amxor_db.d             DJK             @orig_fmt=DKJ
-386e8000 ammax_db.d             DJK             @orig_fmt=DKJ
-386f8000 ammin_db.d             DJK             @orig_fmt=DKJ
-38700000 ammax_db.wu            DJK             @orig_fmt=DKJ
-38708000 ammax_db.du            DJK             @orig_fmt=DKJ
-38710000 ammin_db.wu            DJK             @orig_fmt=DKJ
-38718000 ammin_db.du            DJK             @orig_fmt=DKJ
+22000000 ll.d                   DJSk14          @orig_fmt=DJSk14ps2 @modify=D
+23000000 sc.d                   DJSk14          @orig_fmt=DJSk14ps2 @modify=D
+38570000 sc.q                   DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+38578800 llacq.d                DJ              @rev=1p10 @modify=D
+38578c00 screl.d                DJ              @rev=1p10 @modify=D
+38598000 amcas.d                DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+385b8000 amcas_db.d             DJK             @orig_fmt=DKJ @rev=1p10 @modify=D
+38608000 amswap.d               DJK             @orig_fmt=DKJ @modify=DK
+38618000 amadd.d                DJK             @orig_fmt=DKJ @modify=DK
+38628000 amand.d                DJK             @orig_fmt=DKJ @modify=D
+38638000 amor.d                 DJK             @orig_fmt=DKJ @modify=D
+38648000 amxor.d                DJK             @orig_fmt=DKJ @modify=D
+38658000 ammax.d                DJK             @orig_fmt=DKJ @modify=D
+38668000 ammin.d                DJK             @orig_fmt=DKJ @modify=D
+38670000 ammax.wu               DJK             @orig_fmt=DKJ @modify=D
+38678000 ammax.du               DJK             @orig_fmt=DKJ @modify=D
+38680000 ammin.wu               DJK             @orig_fmt=DKJ @modify=D
+38688000 ammin.du               DJK             @orig_fmt=DKJ @modify=D
+38698000 amswap_db.d            DJK             @orig_fmt=DKJ @modify=D
+386a8000 amadd_db.d             DJK             @orig_fmt=DKJ @modify=D
+386b8000 amand_db.d             DJK             @orig_fmt=DKJ @modify=D
+386c8000 amor_db.d              DJK             @orig_fmt=DKJ @modify=D
+386d8000 amxor_db.d             DJK             @orig_fmt=DKJ @modify=D
+386e8000 ammax_db.d             DJK             @orig_fmt=DKJ @modify=D
+386f8000 ammin_db.d             DJK             @orig_fmt=DKJ @modify=D
+38700000 ammax_db.wu            DJK             @orig_fmt=DKJ @modify=D
+38708000 ammax_db.du            DJK             @orig_fmt=DKJ @modify=D
+38710000 ammin_db.wu            DJK             @orig_fmt=DKJ @modify=D
+38718000 ammin_db.du            DJK             @orig_fmt=DKJ @modify=D

--- a/la-base-32.txt
+++ b/la-base-32.txt
@@ -1,67 +1,67 @@
-00005800 sext.h                 DJ              @orig_name=ext.w.h @la32 @qemu
-00005c00 sext.b                 DJ              @orig_name=ext.w.b @la32 @qemu
-00006000 rdtimel.w              DJ              @la32 @primary
-00006400 rdtimeh.w              DJ              @la32 @primary
-00006c00 cpucfg                 DJ              @la32
-00100000 add.w                  DJK             @la32 @primary @qemu
-00110000 sub.w                  DJK             @la32 @primary @qemu
-00120000 slt                    DJK             @la32 @primary @qemu
-00128000 sltu                   DJK             @la32 @primary @qemu
-00130000 maskeqz                DJK             @la32 @qemu
-00138000 masknez                DJK             @la32 @qemu
-00140000 nor                    DJK             @la32 @primary @qemu
-00148000 and                    DJK             @la32 @primary @qemu
-00150000 or                     DJK             @la32 @primary @qemu
-00158000 xor                    DJK             @la32 @primary @qemu
-00160000 orn                    DJK             @la32 @primary @qemu
-00168000 andn                   DJK             @la32 @primary @qemu
-00170000 sll.w                  DJK             @la32 @primary @qemu
-00178000 srl.w                  DJK             @la32 @primary @qemu
-00180000 sra.w                  DJK             @la32 @primary @qemu
-001b0000 rotr.w                 DJK             @la32 @qemu
+00005800 sext.h                 DJ              @orig_name=ext.w.h @la32 @qemu @modify=D
+00005c00 sext.b                 DJ              @orig_name=ext.w.b @la32 @qemu @modify=D
+00006000 rdtimel.w              DJ              @la32 @primary @modify=DJ
+00006400 rdtimeh.w              DJ              @la32 @primary @modify=DJ
+00006c00 cpucfg                 DJ              @la32 @modify=D
+00100000 add.w                  DJK             @la32 @primary @qemu @modify=D
+00110000 sub.w                  DJK             @la32 @primary @qemu @modify=D
+00120000 slt                    DJK             @la32 @primary @qemu @modify=D
+00128000 sltu                   DJK             @la32 @primary @qemu @modify=D
+00130000 maskeqz                DJK             @la32 @qemu @modify=D
+00138000 masknez                DJK             @la32 @qemu @modify=D
+00140000 nor                    DJK             @la32 @primary @qemu @modify=D
+00148000 and                    DJK             @la32 @primary @qemu @modify=D
+00150000 or                     DJK             @la32 @primary @qemu @modify=D
+00158000 xor                    DJK             @la32 @primary @qemu @modify=D
+00160000 orn                    DJK             @la32 @primary @qemu @modify=D
+00168000 andn                   DJK             @la32 @primary @qemu @modify=D
+00170000 sll.w                  DJK             @la32 @primary @qemu @modify=D
+00178000 srl.w                  DJK             @la32 @primary @qemu @modify=D
+00180000 sra.w                  DJK             @la32 @primary @qemu @modify=D
+001b0000 rotr.w                 DJK             @la32 @qemu @modify=D
 002a0000 break                  Ud15            @la32 @primary
 002a8000 dbgcall                Ud15            @orig_name=dbcl
 002b0000 syscall                Ud15            @la32 @primary
-00408000 slli.w                 DJUk5           @la32 @primary @qemu
-00448000 srli.w                 DJUk5           @la32 @primary @qemu
-00488000 srai.w                 DJUk5           @la32 @primary @qemu
-004c8000 rotri.w                DJUk5           @la32 @qemu
-02000000 slti                   DJSk12          @la32 @primary @qemu
-02400000 sltui                  DJSk12          @la32 @primary @qemu
-02800000 addi.w                 DJSk12          @la32 @primary @qemu
-03400000 andi                   DJUk12          @la32 @primary @qemu
-03800000 ori                    DJUk12          @la32 @primary @qemu
-03c00000 xori                   DJUk12          @la32 @primary @qemu
-14000000 lu12i.w                DSj20           @la32 @primary @qemu
-18000000 pcaddu2i               DSj20           @orig_name=pcaddi @la32 @primary @qemu
-1a000000 pcalau12i              DSj20           @la32 @qemu
-1c000000 pcaddu12i              DSj20           @la32 @primary @qemu
-1e000000 pcaddu18i              DSj20           @qemu
-24000000 ldox4.w                DJSk14          @orig_name=ldptr.w @orig_fmt=DJSk14ps2
+00408000 slli.w                 DJUk5           @la32 @primary @qemu @modify=D
+00448000 srli.w                 DJUk5           @la32 @primary @qemu @modify=D
+00488000 srai.w                 DJUk5           @la32 @primary @qemu @modify=D
+004c8000 rotri.w                DJUk5           @la32 @qemu @modify=D
+02000000 slti                   DJSk12          @la32 @primary @qemu @modify=D
+02400000 sltui                  DJSk12          @la32 @primary @qemu @modify=D
+02800000 addi.w                 DJSk12          @la32 @primary @qemu @modify=D
+03400000 andi                   DJUk12          @la32 @primary @qemu @modify=D
+03800000 ori                    DJUk12          @la32 @primary @qemu @modify=D
+03c00000 xori                   DJUk12          @la32 @primary @qemu @modify=D
+14000000 lu12i.w                DSj20           @la32 @primary @qemu @modify=D
+18000000 pcaddu2i               DSj20           @orig_name=pcaddi @la32 @primary @qemu @modify=D
+1a000000 pcalau12i              DSj20           @la32 @qemu @modify=D
+1c000000 pcaddu12i              DSj20           @la32 @primary @qemu @modify=D
+1e000000 pcaddu18i              DSj20           @qemu @modify=D
+24000000 ldox4.w                DJSk14          @orig_name=ldptr.w @orig_fmt=DJSk14ps2 @modify=D
 25000000 stox4.w                DJSk14          @orig_name=stptr.w @orig_fmt=DJSk14ps2
-28000000 ld.b                   DJSk12          @la32 @primary @qemu
-28400000 ld.h                   DJSk12          @la32 @primary @qemu
-28800000 ld.w                   DJSk12          @la32 @primary @qemu
+28000000 ld.b                   DJSk12          @la32 @primary @qemu @modify=D
+28400000 ld.h                   DJSk12          @la32 @primary @qemu @modify=D
+28800000 ld.w                   DJSk12          @la32 @primary @qemu @modify=D
 29000000 st.b                   DJSk12          @la32 @primary @qemu
 29400000 st.h                   DJSk12          @la32 @primary @qemu
 29800000 st.w                   DJSk12          @la32 @primary @qemu
-2a000000 ld.bu                  DJSk12          @la32 @primary @qemu
-2a400000 ld.hu                  DJSk12          @la32 @primary @qemu
+2a000000 ld.bu                  DJSk12          @la32 @primary @qemu @modify=D
+2a400000 ld.hu                  DJSk12          @la32 @primary @qemu @modify=D
 2ac00000 preld                  JUd5Sk12        @orig_fmt=Ud5JSk12 @la32 @primary
-38000000 ldx.b                  DJK             @qemu
-38040000 ldx.h                  DJK             @qemu
-38080000 ldx.w                  DJK             @qemu
+38000000 ldx.b                  DJK             @qemu @modify=D
+38040000 ldx.h                  DJK             @qemu @modify=D
+38080000 ldx.w                  DJK             @qemu @modify=D
 38100000 stx.b                  DJK             @qemu
 38140000 stx.h                  DJK             @qemu
 38180000 stx.w                  DJK             @qemu
-38200000 ldx.bu                 DJK             @qemu
-38240000 ldx.hu                 DJK             @qemu
+38200000 ldx.bu                 DJK             @qemu @modify=D
+38240000 ldx.hu                 DJK             @qemu @modify=D
 382c0000 preldx                 JKUd5           @orig_fmt=Ud5JK
 38720000 dbar                   Ud15            @la32 @primary @qemu
 38728000 ibar                   Ud15            @la32 @primary
 40000000 beqz                   JSd5k16         @orig_fmt=JSd5k16ps2 @la32
 44000000 bnez                   JSd5k16         @orig_fmt=JSd5k16ps2 @la32
-4c000000 jirl                   DJSk16          @orig_fmt=DJSk16ps2 @la32 @primary @qemu
+4c000000 jirl                   DJSk16          @orig_fmt=DJSk16ps2 @la32 @primary @qemu @modify=D
 50000000 b                      Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @primary @qemu
 54000000 bl                     Sd10k16         @orig_fmt=Sd10k16ps2 @la32 @primary @qemu
 58000000 beq                    DJSk16          @orig_fmt=JDSk16ps2 @la32 @primary @qemu

--- a/la-base-64.txt
+++ b/la-base-64.txt
@@ -1,23 +1,23 @@
-00006800 rdtime.d               DJ
-00108000 add.d                  DJK             @qemu
-00118000 sub.d                  DJK             @qemu
-00188000 sll.d                  DJK             @qemu
-00190000 srl.d                  DJK             @qemu
-00198000 sra.d                  DJK             @qemu
-001b8000 rotr.d                 DJK             @qemu
-00410000 slli.d                 DJUk6           @qemu
-00450000 srli.d                 DJUk6           @qemu
-00490000 srai.d                 DJUk6           @qemu
-004d0000 rotri.d                DJUk6           @qemu
-02c00000 addi.d                 DJSk12          @qemu
-03000000 cu52i.d                DJSk12          @orig_name=lu52i.d @qemu
-10000000 addu16i.d              DJSk16          @qemu
-16000000 cu32i.d                DSj20           @orig_name=lu32i.d @qemu
-26000000 ldox4.d                DJSk14          @orig_name=ldptr.d @orig_fmt=DJSk14ps2
+00006800 rdtime.d               DJ              @modify=DJ
+00108000 add.d                  DJK             @qemu @modify=D
+00118000 sub.d                  DJK             @qemu @modify=D
+00188000 sll.d                  DJK             @qemu @modify=D
+00190000 srl.d                  DJK             @qemu @modify=D
+00198000 sra.d                  DJK             @qemu @modify=D
+001b8000 rotr.d                 DJK             @qemu @modify=D
+00410000 slli.d                 DJUk6           @qemu @modify=D
+00450000 srli.d                 DJUk6           @qemu @modify=D
+00490000 srai.d                 DJUk6           @qemu @modify=D
+004d0000 rotri.d                DJUk6           @qemu @modify=D
+02c00000 addi.d                 DJSk12          @qemu @modify=D
+03000000 cu52i.d                DJSk12          @orig_name=lu52i.d @qemu @modify=D
+10000000 addu16i.d              DJSk16          @qemu @modify=D
+16000000 cu32i.d                DSj20           @orig_name=lu32i.d @qemu @modify=D
+26000000 ldox4.d                DJSk14          @orig_name=ldptr.d @orig_fmt=DJSk14ps2 @modify=D
 27000000 stox4.d                DJSk14          @orig_name=stptr.d @orig_fmt=DJSk14ps2
-28c00000 ld.d                   DJSk12          @qemu
+28c00000 ld.d                   DJSk12          @qemu @modify=D
 29c00000 st.d                   DJSk12          @qemu
-2a800000 ld.wu                  DJSk12          @qemu
-380c0000 ldx.d                  DJK             @qemu
+2a800000 ld.wu                  DJSk12          @qemu @modify=D
+380c0000 ldx.d                  DJK             @qemu @modify=D
 381c0000 stx.d                  DJK             @qemu
-38280000 ldx.wu                 DJK             @qemu
+38280000 ldx.wu                 DJK             @qemu @modify=D

--- a/la-bitops-32.txt
+++ b/la-bitops-32.txt
@@ -1,17 +1,17 @@
-00001000 clo.w                  DJ              @la32
-00001400 clz.w                  DJ              @la32 @qemu
-00001800 cto.w                  DJ              @la32
-00001c00 ctz.w                  DJ              @la32 @qemu
-00003000 revb.2h                DJ              @la32 @qemu
-00004800 revbit.4b              DJ              @orig_name=bitrev.4b @la32
-00005000 revbit.w               DJ              @orig_name=bitrev.w @la32
-00040000 sladd.w                DJKUa2          @orig_name=alsl.w @orig_fmt=DJKUa2pp1 @la32
-00080000 catpick.w              DJKUa2          @orig_name=bytepick.w @la32
-00240000 crc.w.b.w              DJK
-00248000 crc.w.h.w              DJK
-00250000 crc.w.w.w              DJK
-00260000 crcc.w.b.w             DJK
-00268000 crcc.w.h.w             DJK
-00270000 crcc.w.w.w             DJK
-00600000 bstrins.w              DJUk5Um5        @orig_fmt=DJUm5Uk5 @la32 @qemu
-00608000 bstrpick.w             DJUk5Um5        @orig_fmt=DJUm5Uk5 @la32 @qemu
+00001000 clo.w                  DJ              @la32 @modify=D
+00001400 clz.w                  DJ              @la32 @qemu @modify=D
+00001800 cto.w                  DJ              @la32 @modify=D
+00001c00 ctz.w                  DJ              @la32 @qemu @modify=D
+00003000 revb.2h                DJ              @la32 @qemu @modify=D
+00004800 revbit.4b              DJ              @orig_name=bitrev.4b @la32 @modify=D
+00005000 revbit.w               DJ              @orig_name=bitrev.w @la32 @modify=D
+00040000 sladd.w                DJKUa2          @orig_name=alsl.w @orig_fmt=DJKUa2pp1 @la32 @modify=D
+00080000 catpick.w              DJKUa2          @orig_name=bytepick.w @la32 @modify=D
+00240000 crc.w.b.w              DJK             @modify=D
+00248000 crc.w.h.w              DJK             @modify=D
+00250000 crc.w.w.w              DJK             @modify=D
+00260000 crcc.w.b.w             DJK             @modify=D
+00268000 crcc.w.h.w             DJK             @modify=D
+00270000 crcc.w.w.w             DJK             @modify=D
+00600000 bstrins.w              DJUk5Um5        @orig_fmt=DJUm5Uk5 @la32 @qemu @modify=D
+00608000 bstrpick.w             DJUk5Um5        @orig_fmt=DJUm5Uk5 @la32 @qemu @modify=D

--- a/la-bitops-64.txt
+++ b/la-bitops-64.txt
@@ -1,18 +1,18 @@
-00002000 clo.d                  DJ
-00002400 clz.d                  DJ              @qemu
-00002800 cto.d                  DJ
-00002c00 ctz.d                  DJ              @qemu
-00003400 revb.4h                DJ
-00003800 revb.2w                DJ              @qemu
-00003c00 revb.d                 DJ              @qemu
-00004000 revh.2w                DJ
-00004400 revh.d                 DJ
-00004c00 revbit.8b              DJ              @orig_name=bitrev.8b
-00005400 revbit.d               DJ              @orig_name=bitrev.d
-00060000 sladd.wu               DJKUa2          @orig_name=alsl.wu @orig_fmt=DJKUa2pp1
-000c0000 catpick.d              DJKUa3          @orig_name=bytepick.d
-00258000 crc.w.d.w              DJK
-00278000 crcc.w.d.w             DJK
-002c0000 sladd.d                DJKUa2          @orig_name=alsl.d @orig_fmt=DJKUa2pp1
-00800000 bstrins.d              DJUk6Um6        @orig_fmt=DJUm6Uk6 @qemu
-00c00000 bstrpick.d             DJUk6Um6        @orig_fmt=DJUm6Uk6 @qemu
+00002000 clo.d                  DJ              @modify=D
+00002400 clz.d                  DJ              @qemu @modify=D
+00002800 cto.d                  DJ              @modify=D
+00002c00 ctz.d                  DJ              @qemu @modify=D
+00003400 revb.4h                DJ              @modify=D
+00003800 revb.2w                DJ              @qemu @modify=D
+00003c00 revb.d                 DJ              @qemu @modify=D
+00004000 revh.2w                DJ              @modify=D
+00004400 revh.d                 DJ              @modify=D
+00004c00 revbit.8b              DJ              @orig_name=bitrev.8b @modify=D
+00005400 revbit.d               DJ              @orig_name=bitrev.d @modify=D
+00060000 sladd.wu               DJKUa2          @orig_name=alsl.wu @orig_fmt=DJKUa2pp1 @modify=D
+000c0000 catpick.d              DJKUa3          @orig_name=bytepick.d @modify=D
+00258000 crc.w.d.w              DJK             @modify=D
+00278000 crcc.w.d.w             DJK             @modify=D
+002c0000 sladd.d                DJKUa2          @orig_name=alsl.d @orig_fmt=DJKUa2pp1 @modify=D
+00800000 bstrins.d              DJUk6Um6        @orig_fmt=DJUm6Uk6 @qemu @modify=D
+00c00000 bstrpick.d             DJUk6Um6        @orig_fmt=DJUm6Uk6 @qemu @modify=D

--- a/la-bound-64.txt
+++ b/la-bound-64.txt
@@ -1,4 +1,4 @@
-38798000 ldgt.d                 DJK
-387b8000 ldle.d                 DJK
+38798000 ldgt.d                 DJK             @modify=D
+387b8000 ldle.d                 DJK             @modify=D
 387d8000 stgt.d                 DJK
 387f8000 stle.d                 DJK

--- a/la-bound-fp-d.txt
+++ b/la-bound-fp-d.txt
@@ -1,4 +1,4 @@
-38748000 fldgt.d                FdJK
-38758000 fldle.d                FdJK
+38748000 fldgt.d                FdJK            @modify=Fd
+38758000 fldle.d                FdJK            @modify=Fd
 38768000 fstgt.d                FdJK
 38778000 fstle.d                FdJK

--- a/la-bound-fp-s.txt
+++ b/la-bound-fp-s.txt
@@ -1,4 +1,4 @@
-38740000 fldgt.s                FdJK
-38750000 fldle.s                FdJK
+38740000 fldgt.s                FdJK            @modify=Fd
+38750000 fldle.s                FdJK            @modify=Fd
 38760000 fstgt.s                FdJK
 38770000 fstle.s                FdJK

--- a/la-bound.txt
+++ b/la-bound.txt
@@ -1,11 +1,11 @@
 00010000 asrtle                 JK              @orig_name=asrtle.d
 00018000 asrtgt                 JK              @orig_name=asrtgt.d
-38780000 ldgt.b                 DJK
-38788000 ldgt.h                 DJK
-38790000 ldgt.w                 DJK
-387a0000 ldle.b                 DJK
-387a8000 ldle.h                 DJK
-387b0000 ldle.w                 DJK
+38780000 ldgt.b                 DJK             @modify=D
+38788000 ldgt.h                 DJK             @modify=D
+38790000 ldgt.w                 DJK             @modify=D
+387a0000 ldle.b                 DJK             @modify=D
+387a8000 ldle.h                 DJK             @modify=D
+387b0000 ldle.w                 DJK             @modify=D
 387c0000 stgt.b                 DJK
 387c8000 stgt.h                 DJK
 387d0000 stgt.w                 DJK

--- a/la-fp-d.txt
+++ b/la-fp-d.txt
@@ -1,67 +1,67 @@
-01010000 fadd.d                 FdFjFk
-01030000 fsub.d                 FdFjFk
-01050000 fmul.d                 FdFjFk
-01070000 fdiv.d                 FdFjFk
-01090000 fmax.d                 FdFjFk
-010b0000 fmin.d                 FdFjFk
-010d0000 fmaxa.d                FdFjFk
-010f0000 fmina.d                FdFjFk
-01110000 fscaleb.d              FdFjFk
-01130000 fcopysign.d            FdFjFk
-01140800 fabs.d                 FdFj
-01141800 fneg.d                 FdFj
-01142800 flogb.d                FdFj
-01143800 fclass.d               FdFj
-01144800 fsqrt.d                FdFj
-01145800 frecip.d               FdFj
-01146800 frsqrt.d               FdFj
-01147800 frecipe.d              FdFj            @rev=1p10
-01148800 frsqrte.d              FdFj            @rev=1p10
-01149800 fmov.d                 FdFj            @qemu
-0114a800 movgr2fr.d             FdJ             @qemu
-0114b800 movfr2gr.d             DFj             @qemu
-01191800 fcvt.s.d               FdFj
-01192400 fcvt.d.s               FdFj
-011a0800 ftintrm.w.d            FdFj
-011a2800 ftintrm.l.d            FdFj
-011a4800 ftintrp.w.d            FdFj
-011a6800 ftintrp.l.d            FdFj
-011a8800 ftintrz.w.d            FdFj
-011aa800 ftintrz.l.d            FdFj
-011ac800 ftintrne.w.d           FdFj
-011ae800 ftintrne.l.d           FdFj
-011b0800 ftint.w.d              FdFj
-011b2800 ftint.l.d              FdFj
-011d2000 ffint.d.w              FdFj
-011d2800 ffint.d.l              FdFj
-011e4800 frint.d                FdFj
-08200000 fmadd.d                FdFjFkFa
-08600000 fmsub.d                FdFjFkFa
-08a00000 fnmadd.d               FdFjFkFa
-08e00000 fnmsub.d               FdFjFkFa
-0c200000 fcmp.caf.d             CdFjFk
-0c208000 fcmp.saf.d             CdFjFk
-0c210000 fcmp.clt.d             CdFjFk
-0c218000 fcmp.slt.d             CdFjFk
-0c220000 fcmp.ceq.d             CdFjFk
-0c228000 fcmp.seq.d             CdFjFk
-0c230000 fcmp.cle.d             CdFjFk
-0c238000 fcmp.sle.d             CdFjFk
-0c240000 fcmp.cun.d             CdFjFk
-0c248000 fcmp.sun.d             CdFjFk
-0c250000 fcmp.cult.d            CdFjFk
-0c258000 fcmp.sult.d            CdFjFk
-0c260000 fcmp.cueq.d            CdFjFk
-0c268000 fcmp.sueq.d            CdFjFk
-0c270000 fcmp.cule.d            CdFjFk
-0c278000 fcmp.sule.d            CdFjFk
-0c280000 fcmp.cne.d             CdFjFk
-0c288000 fcmp.sne.d             CdFjFk
-0c2a0000 fcmp.cor.d             CdFjFk
-0c2a8000 fcmp.sor.d             CdFjFk
-0c2c0000 fcmp.cune.d            CdFjFk
-0c2c8000 fcmp.sune.d            CdFjFk
-2b800000 fld.d                  FdJSk12         @qemu
+01010000 fadd.d                 FdFjFk          @modify=Fd
+01030000 fsub.d                 FdFjFk          @modify=Fd
+01050000 fmul.d                 FdFjFk          @modify=Fd
+01070000 fdiv.d                 FdFjFk          @modify=Fd
+01090000 fmax.d                 FdFjFk          @modify=Fd
+010b0000 fmin.d                 FdFjFk          @modify=Fd
+010d0000 fmaxa.d                FdFjFk          @modify=Fd
+010f0000 fmina.d                FdFjFk          @modify=Fd
+01110000 fscaleb.d              FdFjFk          @modify=Fd
+01130000 fcopysign.d            FdFjFk          @modify=Fd
+01140800 fabs.d                 FdFj            @modify=Fd
+01141800 fneg.d                 FdFj            @modify=Fd
+01142800 flogb.d                FdFj            @modify=Fd
+01143800 fclass.d               FdFj            @modify=Fd
+01144800 fsqrt.d                FdFj            @modify=Fd
+01145800 frecip.d               FdFj            @modify=Fd
+01146800 frsqrt.d               FdFj            @modify=Fd
+01147800 frecipe.d              FdFj            @rev=1p10 @modify=Fd
+01148800 frsqrte.d              FdFj            @rev=1p10 @modify=Fd
+01149800 fmov.d                 FdFj            @qemu @modify=Fd
+0114a800 movgr2fr.d             FdJ             @qemu @modify=Fd
+0114b800 movfr2gr.d             DFj             @qemu @modify=D
+01191800 fcvt.s.d               FdFj            @modify=Fd
+01192400 fcvt.d.s               FdFj            @modify=Fd
+011a0800 ftintrm.w.d            FdFj            @modify=Fd
+011a2800 ftintrm.l.d            FdFj            @modify=Fd
+011a4800 ftintrp.w.d            FdFj            @modify=Fd
+011a6800 ftintrp.l.d            FdFj            @modify=Fd
+011a8800 ftintrz.w.d            FdFj            @modify=Fd
+011aa800 ftintrz.l.d            FdFj            @modify=Fd
+011ac800 ftintrne.w.d           FdFj            @modify=Fd
+011ae800 ftintrne.l.d           FdFj            @modify=Fd
+011b0800 ftint.w.d              FdFj            @modify=Fd
+011b2800 ftint.l.d              FdFj            @modify=Fd
+011d2000 ffint.d.w              FdFj            @modify=Fd
+011d2800 ffint.d.l              FdFj            @modify=Fd
+011e4800 frint.d                FdFj            @modify=Fd
+08200000 fmadd.d                FdFjFkFa        @modify=Fd
+08600000 fmsub.d                FdFjFkFa        @modify=Fd
+08a00000 fnmadd.d               FdFjFkFa        @modify=Fd
+08e00000 fnmsub.d               FdFjFkFa        @modify=Fd
+0c200000 fcmp.caf.d             CdFjFk          @modify=Cd
+0c208000 fcmp.saf.d             CdFjFk          @modify=Cd
+0c210000 fcmp.clt.d             CdFjFk          @modify=Cd
+0c218000 fcmp.slt.d             CdFjFk          @modify=Cd
+0c220000 fcmp.ceq.d             CdFjFk          @modify=Cd
+0c228000 fcmp.seq.d             CdFjFk          @modify=Cd
+0c230000 fcmp.cle.d             CdFjFk          @modify=Cd
+0c238000 fcmp.sle.d             CdFjFk          @modify=Cd
+0c240000 fcmp.cun.d             CdFjFk          @modify=Cd
+0c248000 fcmp.sun.d             CdFjFk          @modify=Cd
+0c250000 fcmp.cult.d            CdFjFk          @modify=Cd
+0c258000 fcmp.sult.d            CdFjFk          @modify=Cd
+0c260000 fcmp.cueq.d            CdFjFk          @modify=Cd
+0c268000 fcmp.sueq.d            CdFjFk          @modify=Cd
+0c270000 fcmp.cule.d            CdFjFk          @modify=Cd
+0c278000 fcmp.sule.d            CdFjFk          @modify=Cd
+0c280000 fcmp.cne.d             CdFjFk          @modify=Cd
+0c288000 fcmp.sne.d             CdFjFk          @modify=Cd
+0c2a0000 fcmp.cor.d             CdFjFk          @modify=Cd
+0c2a8000 fcmp.sor.d             CdFjFk          @modify=Cd
+0c2c0000 fcmp.cune.d            CdFjFk          @modify=Cd
+0c2c8000 fcmp.sune.d            CdFjFk          @modify=Cd
+2b800000 fld.d                  FdJSk12         @qemu @modify=Fd
 2bc00000 fst.d                  FdJSk12         @qemu
-38340000 fldx.d                 FdJK            @qemu
+38340000 fldx.d                 FdJK            @qemu @modify=Fd
 383c0000 fstx.d                 FdJK            @qemu

--- a/la-fp-s.txt
+++ b/la-fp-s.txt
@@ -1,67 +1,67 @@
-01008000 fadd.s                 FdFjFk
-01028000 fsub.s                 FdFjFk
-01048000 fmul.s                 FdFjFk
-01068000 fdiv.s                 FdFjFk
-01088000 fmax.s                 FdFjFk
-010a8000 fmin.s                 FdFjFk
-010c8000 fmaxa.s                FdFjFk
-010e8000 fmina.s                FdFjFk
-01108000 fscaleb.s              FdFjFk
-01128000 fcopysign.s            FdFjFk
-01140400 fabs.s                 FdFj
-01141400 fneg.s                 FdFj
-01142400 flogb.s                FdFj
-01143400 fclass.s               FdFj
-01144400 fsqrt.s                FdFj
-01145400 frecip.s               FdFj
-01146400 frsqrt.s               FdFj
-01147400 frecipe.s              FdFj            @rev=1p10
-01148400 frsqrte.s              FdFj            @rev=1p10
-01149400 fmov.s                 FdFj
-0114a400 movgr2fr.w             FdJ
-0114ac00 movgr2frh.w            FdJ
-0114b400 movfr2gr.s             DFj
-0114bc00 movfrh2gr.s            DFj
-011a0400 ftintrm.w.s            FdFj
-011a2400 ftintrm.l.s            FdFj
-011a4400 ftintrp.w.s            FdFj
-011a6400 ftintrp.l.s            FdFj
-011a8400 ftintrz.w.s            FdFj
-011aa400 ftintrz.l.s            FdFj
-011ac400 ftintrne.w.s           FdFj
-011ae400 ftintrne.l.s           FdFj
-011b0400 ftint.w.s              FdFj
-011b2400 ftint.l.s              FdFj
-011d1000 ffint.s.w              FdFj
-011d1800 ffint.s.l              FdFj
-011e4400 frint.s                FdFj
-08100000 fmadd.s                FdFjFkFa
-08500000 fmsub.s                FdFjFkFa
-08900000 fnmadd.s               FdFjFkFa
-08d00000 fnmsub.s               FdFjFkFa
-0c100000 fcmp.caf.s             CdFjFk
-0c108000 fcmp.saf.s             CdFjFk
-0c110000 fcmp.clt.s             CdFjFk
-0c118000 fcmp.slt.s             CdFjFk
-0c120000 fcmp.ceq.s             CdFjFk
-0c128000 fcmp.seq.s             CdFjFk
-0c130000 fcmp.cle.s             CdFjFk
-0c138000 fcmp.sle.s             CdFjFk
-0c140000 fcmp.cun.s             CdFjFk
-0c148000 fcmp.sun.s             CdFjFk
-0c150000 fcmp.cult.s            CdFjFk
-0c158000 fcmp.sult.s            CdFjFk
-0c160000 fcmp.cueq.s            CdFjFk
-0c168000 fcmp.sueq.s            CdFjFk
-0c170000 fcmp.cule.s            CdFjFk
-0c178000 fcmp.sule.s            CdFjFk
-0c180000 fcmp.cne.s             CdFjFk
-0c188000 fcmp.sne.s             CdFjFk
-0c1a0000 fcmp.cor.s             CdFjFk
-0c1a8000 fcmp.sor.s             CdFjFk
-0c1c0000 fcmp.cune.s            CdFjFk
-0c1c8000 fcmp.sune.s            CdFjFk
-2b000000 fld.s                  FdJSk12         @qemu
+01008000 fadd.s                 FdFjFk          @modify=Fd
+01028000 fsub.s                 FdFjFk          @modify=Fd
+01048000 fmul.s                 FdFjFk          @modify=Fd
+01068000 fdiv.s                 FdFjFk          @modify=Fd
+01088000 fmax.s                 FdFjFk          @modify=Fd
+010a8000 fmin.s                 FdFjFk          @modify=Fd
+010c8000 fmaxa.s                FdFjFk          @modify=Fd
+010e8000 fmina.s                FdFjFk          @modify=Fd
+01108000 fscaleb.s              FdFjFk          @modify=Fd
+01128000 fcopysign.s            FdFjFk          @modify=Fd
+01140400 fabs.s                 FdFj            @modify=Fd
+01141400 fneg.s                 FdFj            @modify=Fd
+01142400 flogb.s                FdFj            @modify=Fd
+01143400 fclass.s               FdFj            @modify=Fd
+01144400 fsqrt.s                FdFj            @modify=Fd
+01145400 frecip.s               FdFj            @modify=Fd
+01146400 frsqrt.s               FdFj            @modify=Fd
+01147400 frecipe.s              FdFj            @rev=1p10 @modify=Fd
+01148400 frsqrte.s              FdFj            @rev=1p10 @modify=Fd
+01149400 fmov.s                 FdFj            @modify=Fd
+0114a400 movgr2fr.w             FdJ             @modify=Fd
+0114ac00 movgr2frh.w            FdJ             @modify=Fd
+0114b400 movfr2gr.s             DFj             @modify=D
+0114bc00 movfrh2gr.s            DFj             @modify=D
+011a0400 ftintrm.w.s            FdFj            @modify=Fd
+011a2400 ftintrm.l.s            FdFj            @modify=Fd
+011a4400 ftintrp.w.s            FdFj            @modify=Fd
+011a6400 ftintrp.l.s            FdFj            @modify=Fd
+011a8400 ftintrz.w.s            FdFj            @modify=Fd
+011aa400 ftintrz.l.s            FdFj            @modify=Fd
+011ac400 ftintrne.w.s           FdFj            @modify=Fd
+011ae400 ftintrne.l.s           FdFj            @modify=Fd
+011b0400 ftint.w.s              FdFj            @modify=Fd
+011b2400 ftint.l.s              FdFj            @modify=Fd
+011d1000 ffint.s.w              FdFj            @modify=Fd
+011d1800 ffint.s.l              FdFj            @modify=Fd
+011e4400 frint.s                FdFj            @modify=Fd
+08100000 fmadd.s                FdFjFkFa        @modify=Fd
+08500000 fmsub.s                FdFjFkFa        @modify=Fd
+08900000 fnmadd.s               FdFjFkFa        @modify=Fd
+08d00000 fnmsub.s               FdFjFkFa        @modify=Fd
+0c100000 fcmp.caf.s             CdFjFk          @modify=Cd
+0c108000 fcmp.saf.s             CdFjFk          @modify=Cd
+0c110000 fcmp.clt.s             CdFjFk          @modify=Cd
+0c118000 fcmp.slt.s             CdFjFk          @modify=Cd
+0c120000 fcmp.ceq.s             CdFjFk          @modify=Cd
+0c128000 fcmp.seq.s             CdFjFk          @modify=Cd
+0c130000 fcmp.cle.s             CdFjFk          @modify=Cd
+0c138000 fcmp.sle.s             CdFjFk          @modify=Cd
+0c140000 fcmp.cun.s             CdFjFk          @modify=Cd
+0c148000 fcmp.sun.s             CdFjFk          @modify=Cd
+0c150000 fcmp.cult.s            CdFjFk          @modify=Cd
+0c158000 fcmp.sult.s            CdFjFk          @modify=Cd
+0c160000 fcmp.cueq.s            CdFjFk          @modify=Cd
+0c168000 fcmp.sueq.s            CdFjFk          @modify=Cd
+0c170000 fcmp.cule.s            CdFjFk          @modify=Cd
+0c178000 fcmp.sule.s            CdFjFk          @modify=Cd
+0c180000 fcmp.cne.s             CdFjFk          @modify=Cd
+0c188000 fcmp.sne.s             CdFjFk          @modify=Cd
+0c1a0000 fcmp.cor.s             CdFjFk          @modify=Cd
+0c1a8000 fcmp.sor.s             CdFjFk          @modify=Cd
+0c1c0000 fcmp.cune.s            CdFjFk          @modify=Cd
+0c1c8000 fcmp.sune.s            CdFjFk          @modify=Cd
+2b000000 fld.s                  FdJSk12         @qemu @modify=Fd
 2b400000 fst.s                  FdJSk12         @qemu
-38300000 fldx.s                 FdJK            @qemu
+38300000 fldx.s                 FdJK            @qemu @modify=Fd
 38380000 fstx.s                 FdJK            @qemu

--- a/la-fp.txt
+++ b/la-fp.txt
@@ -1,9 +1,9 @@
-0114c000 fcsrwr                 JUd5            @orig_name=movgr2fcsr @orig_fmt=DJ
-0114c800 fcsrrd                 DUj5            @orig_name=movfcsr2gr @orig_fmt=DJ
-0114d000 movfr2fcc              CdFj            @orig_name=movfr2cf
-0114d400 movfcc2fr              FdCj            @orig_name=movcf2fr
-0114d800 movgr2fcc              CdJ             @orig_name=movgr2cf
-0114dc00 movfcc2gr              DCj             @orig_name=movcf2gr
-0d000000 fsel                   FdFjFkCa
+0114c000 fcsrwr                 JUd5            @orig_name=movgr2fcsr @orig_fmt=DJ @modify=J
+0114c800 fcsrrd                 DUj5            @orig_name=movfcsr2gr @orig_fmt=DJ @modify=D
+0114d000 movfr2fcc              CdFj            @orig_name=movfr2cf @modify=Cd
+0114d400 movfcc2fr              FdCj            @orig_name=movcf2fr @modify=Fd
+0114d800 movgr2fcc              CdJ             @orig_name=movgr2cf @modify=Cd
+0114dc00 movfcc2gr              DCj             @orig_name=movcf2gr @modify=D
+0d000000 fsel                   FdFjFkCa        @modify=Fd
 48000000 bceqz                  CjSd5k16        @orig_fmt=CjSd5k16ps2
 48000100 bcnez                  CjSd5k16        @orig_fmt=CjSd5k16ps2

--- a/la-mul-32.txt
+++ b/la-mul-32.txt
@@ -1,7 +1,7 @@
-001c0000 mul.w                  DJK             @la32 @primary @qemu
-001c8000 mulh.w                 DJK             @la32 @primary @qemu
-001d0000 mulh.wu                DJK             @la32 @primary @qemu
-00200000 div.w                  DJK             @la32 @primary @qemu
-00208000 mod.w                  DJK             @la32 @primary @qemu
-00210000 div.wu                 DJK             @la32 @primary @qemu
-00218000 mod.wu                 DJK             @la32 @primary @qemu
+001c0000 mul.w                  DJK             @la32 @primary @qemu @modify=D
+001c8000 mulh.w                 DJK             @la32 @primary @qemu @modify=D
+001d0000 mulh.wu                DJK             @la32 @primary @qemu @modify=D
+00200000 div.w                  DJK             @la32 @primary @qemu @modify=D
+00208000 mod.w                  DJK             @la32 @primary @qemu @modify=D
+00210000 div.wu                 DJK             @la32 @primary @qemu @modify=D
+00218000 mod.wu                 DJK             @la32 @primary @qemu @modify=D

--- a/la-mul-64.txt
+++ b/la-mul-64.txt
@@ -1,9 +1,9 @@
-001d8000 mul.d                  DJK             @qemu
-001e0000 mulh.d                 DJK             @qemu
-001e8000 mulh.du                DJK             @qemu
-001f0000 mulw.d.w               DJK
-001f8000 mulw.d.wu              DJK
-00220000 div.d                  DJK             @qemu
-00228000 mod.d                  DJK             @qemu
-00230000 div.du                 DJK             @qemu
-00238000 mod.du                 DJK             @qemu
+001d8000 mul.d                  DJK             @qemu @modify=D
+001e0000 mulh.d                 DJK             @qemu @modify=D
+001e8000 mulh.du                DJK             @qemu @modify=D
+001f0000 mulw.d.w               DJK             @modify=D
+001f8000 mulw.d.wu              DJK             @modify=D
+00220000 div.d                  DJK             @qemu @modify=D
+00228000 mod.d                  DJK             @qemu @modify=D
+00230000 div.du                 DJK             @qemu @modify=D
+00238000 mod.du                 DJK             @qemu @modify=D

--- a/la-privileged-32.txt
+++ b/la-privileged-32.txt
@@ -1,10 +1,10 @@
-04000000 csrxchg                DJUk14          @primary
+04000000 csrxchg                DJUk14          @primary @modify=D
 06000000 cacop                  JUd5Sk12        @orig_fmt=Ud5JSk12 @primary
-06400000 lddir                  DJUk8
+06400000 lddir                  DJUk8           @modify=D
 06440000 ldpte                  JUk8
-06480000 iocsrrd.b              DJ
-06480400 iocsrrd.h              DJ
-06480800 iocsrrd.w              DJ
+06480000 iocsrrd.b              DJ              @modify=D
+06480400 iocsrrd.h              DJ              @modify=D
+06480800 iocsrrd.w              DJ              @modify=D
 06481000 iocsrwr.b              DJ
 06481400 iocsrwr.h              DJ
 06481800 iocsrwr.w              DJ
@@ -17,4 +17,4 @@
 06483800 eret                   EMPTY           @orig_name=ertn @primary
 06488000 idle                   Ud15            @primary
 06493000 xxx.unknown.1          EMPTY           @provisional
-06498000 tlbinv                 JKUd5           @orig_name=invtlb @orig_fmt=Ud5JK @primary
+06498000 tlbinv                 JKUd5           @orig_name=invtlb @orig_fmt=Ud5JK @primary @modify=JK

--- a/la-privileged-64.txt
+++ b/la-privileged-64.txt
@@ -1,2 +1,2 @@
-06480c00 iocsrrd.d              DJ
+06480c00 iocsrrd.d              DJ              @modify=D
 06481c00 iocsrwr.d              DJ

--- a/lasx.txt
+++ b/lasx.txt
@@ -1,735 +1,735 @@
-0a100000 xvfmadd.s              XdXjXkXa
-0a200000 xvfmadd.d              XdXjXkXa
-0a500000 xvfmsub.s              XdXjXkXa
-0a600000 xvfmsub.d              XdXjXkXa
-0a900000 xvfnmadd.s             XdXjXkXa
-0aa00000 xvfnmadd.d             XdXjXkXa
-0ad00000 xvfnmsub.s             XdXjXkXa
-0ae00000 xvfnmsub.d             XdXjXkXa
-0c900000 xvfcmp.caf.s           XdXjXk
-0c908000 xvfcmp.saf.s           XdXjXk
-0c910000 xvfcmp.clt.s           XdXjXk
-0c918000 xvfcmp.slt.s           XdXjXk
-0c920000 xvfcmp.ceq.s           XdXjXk
-0c928000 xvfcmp.seq.s           XdXjXk
-0c930000 xvfcmp.cle.s           XdXjXk
-0c938000 xvfcmp.sle.s           XdXjXk
-0c940000 xvfcmp.cun.s           XdXjXk
-0c948000 xvfcmp.sun.s           XdXjXk
-0c950000 xvfcmp.cult.s          XdXjXk
-0c958000 xvfcmp.sult.s          XdXjXk
-0c960000 xvfcmp.cueq.s          XdXjXk
-0c968000 xvfcmp.sueq.s          XdXjXk
-0c970000 xvfcmp.cule.s          XdXjXk
-0c978000 xvfcmp.sule.s          XdXjXk
-0c980000 xvfcmp.cne.s           XdXjXk
-0c988000 xvfcmp.sne.s           XdXjXk
-0c9a0000 xvfcmp.cor.s           XdXjXk
-0c9a8000 xvfcmp.sor.s           XdXjXk
-0c9c0000 xvfcmp.cune.s          XdXjXk
-0c9c8000 xvfcmp.sune.s          XdXjXk
-0ca00000 xvfcmp.caf.d           XdXjXk
-0ca08000 xvfcmp.saf.d           XdXjXk
-0ca10000 xvfcmp.clt.d           XdXjXk
-0ca18000 xvfcmp.slt.d           XdXjXk
-0ca20000 xvfcmp.ceq.d           XdXjXk
-0ca28000 xvfcmp.seq.d           XdXjXk
-0ca30000 xvfcmp.cle.d           XdXjXk
-0ca38000 xvfcmp.sle.d           XdXjXk
-0ca40000 xvfcmp.cun.d           XdXjXk
-0ca48000 xvfcmp.sun.d           XdXjXk
-0ca50000 xvfcmp.cult.d          XdXjXk
-0ca58000 xvfcmp.sult.d          XdXjXk
-0ca60000 xvfcmp.cueq.d          XdXjXk
-0ca68000 xvfcmp.sueq.d          XdXjXk
-0ca70000 xvfcmp.cule.d          XdXjXk
-0ca78000 xvfcmp.sule.d          XdXjXk
-0ca80000 xvfcmp.cne.d           XdXjXk
-0ca88000 xvfcmp.sne.d           XdXjXk
-0caa0000 xvfcmp.cor.d           XdXjXk
-0caa8000 xvfcmp.sor.d           XdXjXk
-0cac0000 xvfcmp.cune.d          XdXjXk
-0cac8000 xvfcmp.sune.d          XdXjXk
-0d200000 xvbitsel.v             XdXjXkXa        @qemu
-0d600000 xvshuf.b               XdXjXkXa        @qemu
-2c800000 xvld                   XdJSk12         @qemu
-2cc00000 xvst                   XdJSk12         @qemu
-32100000 xvldrepl.d             XdJSk9          @orig_fmt=XdJSk9ps3 @qemu
-32200000 xvldrepl.w             XdJSk10         @orig_fmt=XdJSk10ps2 @qemu
-32400000 xvldrepl.h             XdJSk11         @orig_fmt=XdJSk11ps1 @qemu
-32800000 xvldrepl.b             XdJSk12         @qemu
-33100000 xvstelm.d              XdJSk8Un2       @orig_fmt=XdJSk8ps3Un2 @qemu
-33200000 xvstelm.w              XdJSk8Un3       @orig_fmt=XdJSk8ps2Un3 @qemu
-33400000 xvstelm.h              XdJSk8Un4       @orig_fmt=XdJSk8ps1Un4 @qemu
-33800000 xvstelm.b              XdJSk8Un5       @qemu
-38480000 xvldx                  XdJK            @qemu
-384c0000 xvstx                  XdJK            @qemu
-74000000 xvseq.b                XdXjXk          @qemu
-74008000 xvseq.h                XdXjXk          @qemu
-74010000 xvseq.w                XdXjXk          @qemu
-74018000 xvseq.d                XdXjXk          @qemu
-74020000 xvsle.b                XdXjXk          @qemu
-74028000 xvsle.h                XdXjXk          @qemu
-74030000 xvsle.w                XdXjXk          @qemu
-74038000 xvsle.d                XdXjXk          @qemu
-74040000 xvsle.bu               XdXjXk          @qemu
-74048000 xvsle.hu               XdXjXk          @qemu
-74050000 xvsle.wu               XdXjXk          @qemu
-74058000 xvsle.du               XdXjXk          @qemu
-74060000 xvslt.b                XdXjXk          @qemu
-74068000 xvslt.h                XdXjXk          @qemu
-74070000 xvslt.w                XdXjXk          @qemu
-74078000 xvslt.d                XdXjXk          @qemu
-74080000 xvslt.bu               XdXjXk          @qemu
-74088000 xvslt.hu               XdXjXk          @qemu
-74090000 xvslt.wu               XdXjXk          @qemu
-74098000 xvslt.du               XdXjXk          @qemu
-740a0000 xvadd.b                XdXjXk          @qemu
-740a8000 xvadd.h                XdXjXk          @qemu
-740b0000 xvadd.w                XdXjXk          @qemu
-740b8000 xvadd.d                XdXjXk          @qemu
-740c0000 xvsub.b                XdXjXk          @qemu
-740c8000 xvsub.h                XdXjXk          @qemu
-740d0000 xvsub.w                XdXjXk          @qemu
-740d8000 xvsub.d                XdXjXk          @qemu
-741e0000 xvaddwev.h.b           XdXjXk
-741e8000 xvaddwev.w.h           XdXjXk
-741f0000 xvaddwev.d.w           XdXjXk
-741f8000 xvaddwev.q.d           XdXjXk
-74200000 xvsubwev.h.b           XdXjXk
-74208000 xvsubwev.w.h           XdXjXk
-74210000 xvsubwev.d.w           XdXjXk
-74218000 xvsubwev.q.d           XdXjXk
-74220000 xvaddwod.h.b           XdXjXk
-74228000 xvaddwod.w.h           XdXjXk
-74230000 xvaddwod.d.w           XdXjXk
-74238000 xvaddwod.q.d           XdXjXk
-74240000 xvsubwod.h.b           XdXjXk
-74248000 xvsubwod.w.h           XdXjXk
-74250000 xvsubwod.d.w           XdXjXk
-74258000 xvsubwod.q.d           XdXjXk
-742e0000 xvaddwev.h.bu          XdXjXk
-742e8000 xvaddwev.w.hu          XdXjXk
-742f0000 xvaddwev.d.wu          XdXjXk
-742f8000 xvaddwev.q.du          XdXjXk
-74300000 xvsubwev.h.bu          XdXjXk
-74308000 xvsubwev.w.hu          XdXjXk
-74310000 xvsubwev.d.wu          XdXjXk
-74318000 xvsubwev.q.du          XdXjXk
-74320000 xvaddwod.h.bu          XdXjXk
-74328000 xvaddwod.w.hu          XdXjXk
-74330000 xvaddwod.d.wu          XdXjXk
-74338000 xvaddwod.q.du          XdXjXk
-74340000 xvsubwod.h.bu          XdXjXk
-74348000 xvsubwod.w.hu          XdXjXk
-74350000 xvsubwod.d.wu          XdXjXk
-74358000 xvsubwod.q.du          XdXjXk
-743e0000 xvaddwev.h.bu.b        XdXjXk
-743e8000 xvaddwev.w.hu.h        XdXjXk
-743f0000 xvaddwev.d.wu.w        XdXjXk
-743f8000 xvaddwev.q.du.d        XdXjXk
-74400000 xvaddwod.h.bu.b        XdXjXk
-74408000 xvaddwod.w.hu.h        XdXjXk
-74410000 xvaddwod.d.wu.w        XdXjXk
-74418000 xvaddwod.q.du.d        XdXjXk
-74460000 xvsadd.b               XdXjXk          @qemu
-74468000 xvsadd.h               XdXjXk          @qemu
-74470000 xvsadd.w               XdXjXk          @qemu
-74478000 xvsadd.d               XdXjXk          @qemu
-74480000 xvssub.b               XdXjXk          @qemu
-74488000 xvssub.h               XdXjXk          @qemu
-74490000 xvssub.w               XdXjXk          @qemu
-74498000 xvssub.d               XdXjXk          @qemu
-744a0000 xvsadd.bu              XdXjXk          @qemu
-744a8000 xvsadd.hu              XdXjXk          @qemu
-744b0000 xvsadd.wu              XdXjXk          @qemu
-744b8000 xvsadd.du              XdXjXk          @qemu
-744c0000 xvssub.bu              XdXjXk          @qemu
-744c8000 xvssub.hu              XdXjXk          @qemu
-744d0000 xvssub.wu              XdXjXk          @qemu
-744d8000 xvssub.du              XdXjXk          @qemu
-74540000 xvhaddw.h.b            XdXjXk
-74548000 xvhaddw.w.h            XdXjXk
-74550000 xvhaddw.d.w            XdXjXk
-74558000 xvhaddw.q.d            XdXjXk
-74560000 xvhsubw.h.b            XdXjXk
-74568000 xvhsubw.w.h            XdXjXk
-74570000 xvhsubw.d.w            XdXjXk
-74578000 xvhsubw.q.d            XdXjXk
-74580000 xvhaddw.hu.bu          XdXjXk
-74588000 xvhaddw.wu.hu          XdXjXk
-74590000 xvhaddw.du.wu          XdXjXk
-74598000 xvhaddw.qu.du          XdXjXk
-745a0000 xvhsubw.hu.bu          XdXjXk
-745a8000 xvhsubw.wu.hu          XdXjXk
-745b0000 xvhsubw.du.wu          XdXjXk
-745b8000 xvhsubw.qu.du          XdXjXk
-745c0000 xvadda.b               XdXjXk
-745c8000 xvadda.h               XdXjXk
-745d0000 xvadda.w               XdXjXk
-745d8000 xvadda.d               XdXjXk
-74600000 xvabsd.b               XdXjXk
-74608000 xvabsd.h               XdXjXk
-74610000 xvabsd.w               XdXjXk
-74618000 xvabsd.d               XdXjXk
-74620000 xvabsd.bu              XdXjXk
-74628000 xvabsd.hu              XdXjXk
-74630000 xvabsd.wu              XdXjXk
-74638000 xvabsd.du              XdXjXk
-74640000 xvavg.b                XdXjXk
-74648000 xvavg.h                XdXjXk
-74650000 xvavg.w                XdXjXk
-74658000 xvavg.d                XdXjXk
-74660000 xvavg.bu               XdXjXk
-74668000 xvavg.hu               XdXjXk
-74670000 xvavg.wu               XdXjXk
-74678000 xvavg.du               XdXjXk
-74680000 xvavgr.b               XdXjXk
-74688000 xvavgr.h               XdXjXk
-74690000 xvavgr.w               XdXjXk
-74698000 xvavgr.d               XdXjXk
-746a0000 xvavgr.bu              XdXjXk
-746a8000 xvavgr.hu              XdXjXk
-746b0000 xvavgr.wu              XdXjXk
-746b8000 xvavgr.du              XdXjXk
-74700000 xvmax.b                XdXjXk          @qemu
-74708000 xvmax.h                XdXjXk          @qemu
-74710000 xvmax.w                XdXjXk          @qemu
-74718000 xvmax.d                XdXjXk          @qemu
-74720000 xvmin.b                XdXjXk          @qemu
-74728000 xvmin.h                XdXjXk          @qemu
-74730000 xvmin.w                XdXjXk          @qemu
-74738000 xvmin.d                XdXjXk          @qemu
-74740000 xvmax.bu               XdXjXk          @qemu
-74748000 xvmax.hu               XdXjXk          @qemu
-74750000 xvmax.wu               XdXjXk          @qemu
-74758000 xvmax.du               XdXjXk          @qemu
-74760000 xvmin.bu               XdXjXk          @qemu
-74768000 xvmin.hu               XdXjXk          @qemu
-74770000 xvmin.wu               XdXjXk          @qemu
-74778000 xvmin.du               XdXjXk          @qemu
-74840000 xvmul.b                XdXjXk          @qemu
-74848000 xvmul.h                XdXjXk          @qemu
-74850000 xvmul.w                XdXjXk          @qemu
-74858000 xvmul.d                XdXjXk          @qemu
-74860000 xvmuh.b                XdXjXk
-74868000 xvmuh.h                XdXjXk
-74870000 xvmuh.w                XdXjXk
-74878000 xvmuh.d                XdXjXk
-74880000 xvmuh.bu               XdXjXk
-74888000 xvmuh.hu               XdXjXk
-74890000 xvmuh.wu               XdXjXk
-74898000 xvmuh.du               XdXjXk
-74900000 xvmulwev.h.b           XdXjXk
-74908000 xvmulwev.w.h           XdXjXk
-74910000 xvmulwev.d.w           XdXjXk
-74918000 xvmulwev.q.d           XdXjXk
-74920000 xvmulwod.h.b           XdXjXk
-74928000 xvmulwod.w.h           XdXjXk
-74930000 xvmulwod.d.w           XdXjXk
-74938000 xvmulwod.q.d           XdXjXk
-74980000 xvmulwev.h.bu          XdXjXk
-74988000 xvmulwev.w.hu          XdXjXk
-74990000 xvmulwev.d.wu          XdXjXk
-74998000 xvmulwev.q.du          XdXjXk
-749a0000 xvmulwod.h.bu          XdXjXk
-749a8000 xvmulwod.w.hu          XdXjXk
-749b0000 xvmulwod.d.wu          XdXjXk
-749b8000 xvmulwod.q.du          XdXjXk
-74a00000 xvmulwev.h.bu.b        XdXjXk
-74a08000 xvmulwev.w.hu.h        XdXjXk
-74a10000 xvmulwev.d.wu.w        XdXjXk
-74a18000 xvmulwev.q.du.d        XdXjXk
-74a20000 xvmulwod.h.bu.b        XdXjXk
-74a28000 xvmulwod.w.hu.h        XdXjXk
-74a30000 xvmulwod.d.wu.w        XdXjXk
-74a38000 xvmulwod.q.du.d        XdXjXk
-74a80000 xvmadd.b               XdXjXk
-74a88000 xvmadd.h               XdXjXk
-74a90000 xvmadd.w               XdXjXk
-74a98000 xvmadd.d               XdXjXk
-74aa0000 xvmsub.b               XdXjXk
-74aa8000 xvmsub.h               XdXjXk
-74ab0000 xvmsub.w               XdXjXk
-74ab8000 xvmsub.d               XdXjXk
-74ac0000 xvmaddwev.h.b          XdXjXk
-74ac8000 xvmaddwev.w.h          XdXjXk
-74ad0000 xvmaddwev.d.w          XdXjXk
-74ad8000 xvmaddwev.q.d          XdXjXk
-74ae0000 xvmaddwod.h.b          XdXjXk
-74ae8000 xvmaddwod.w.h          XdXjXk
-74af0000 xvmaddwod.d.w          XdXjXk
-74af8000 xvmaddwod.q.d          XdXjXk
-74b40000 xvmaddwev.h.bu         XdXjXk
-74b48000 xvmaddwev.w.hu         XdXjXk
-74b50000 xvmaddwev.d.wu         XdXjXk
-74b58000 xvmaddwev.q.du         XdXjXk
-74b60000 xvmaddwod.h.bu         XdXjXk
-74b68000 xvmaddwod.w.hu         XdXjXk
-74b70000 xvmaddwod.d.wu         XdXjXk
-74b78000 xvmaddwod.q.du         XdXjXk
-74bc0000 xvmaddwev.h.bu.b       XdXjXk
-74bc8000 xvmaddwev.w.hu.h       XdXjXk
-74bd0000 xvmaddwev.d.wu.w       XdXjXk
-74bd8000 xvmaddwev.q.du.d       XdXjXk
-74be0000 xvmaddwod.h.bu.b       XdXjXk
-74be8000 xvmaddwod.w.hu.h       XdXjXk
-74bf0000 xvmaddwod.d.wu.w       XdXjXk
-74bf8000 xvmaddwod.q.du.d       XdXjXk
-74e00000 xvdiv.b                XdXjXk
-74e08000 xvdiv.h                XdXjXk
-74e10000 xvdiv.w                XdXjXk
-74e18000 xvdiv.d                XdXjXk
-74e20000 xvmod.b                XdXjXk
-74e28000 xvmod.h                XdXjXk
-74e30000 xvmod.w                XdXjXk
-74e38000 xvmod.d                XdXjXk
-74e40000 xvdiv.bu               XdXjXk
-74e48000 xvdiv.hu               XdXjXk
-74e50000 xvdiv.wu               XdXjXk
-74e58000 xvdiv.du               XdXjXk
-74e60000 xvmod.bu               XdXjXk
-74e68000 xvmod.hu               XdXjXk
-74e70000 xvmod.wu               XdXjXk
-74e78000 xvmod.du               XdXjXk
-74e80000 xvsll.b                XdXjXk          @qemu
-74e88000 xvsll.h                XdXjXk          @qemu
-74e90000 xvsll.w                XdXjXk          @qemu
-74e98000 xvsll.d                XdXjXk          @qemu
-74ea0000 xvsrl.b                XdXjXk          @qemu
-74ea8000 xvsrl.h                XdXjXk          @qemu
-74eb0000 xvsrl.w                XdXjXk          @qemu
-74eb8000 xvsrl.d                XdXjXk          @qemu
-74ec0000 xvsra.b                XdXjXk          @qemu
-74ec8000 xvsra.h                XdXjXk          @qemu
-74ed0000 xvsra.w                XdXjXk          @qemu
-74ed8000 xvsra.d                XdXjXk          @qemu
-74ee0000 xvrotr.b               XdXjXk          @qemu
-74ee8000 xvrotr.h               XdXjXk          @qemu
-74ef0000 xvrotr.w               XdXjXk          @qemu
-74ef8000 xvrotr.d               XdXjXk          @qemu
-74f00000 xvsrlr.b               XdXjXk
-74f08000 xvsrlr.h               XdXjXk
-74f10000 xvsrlr.w               XdXjXk
-74f18000 xvsrlr.d               XdXjXk
-74f20000 xvsrar.b               XdXjXk
-74f28000 xvsrar.h               XdXjXk
-74f30000 xvsrar.w               XdXjXk
-74f38000 xvsrar.d               XdXjXk
-74f48000 xvsrln.b.h             XdXjXk
-74f50000 xvsrln.h.w             XdXjXk
-74f58000 xvsrln.w.d             XdXjXk
-74f68000 xvsran.b.h             XdXjXk
-74f70000 xvsran.h.w             XdXjXk
-74f78000 xvsran.w.d             XdXjXk
-74f88000 xvsrlrn.b.h            XdXjXk
-74f90000 xvsrlrn.h.w            XdXjXk
-74f98000 xvsrlrn.w.d            XdXjXk
-74fa8000 xvsrarn.b.h            XdXjXk
-74fb0000 xvsrarn.h.w            XdXjXk
-74fb8000 xvsrarn.w.d            XdXjXk
-74fc8000 xvssrln.b.h            XdXjXk
-74fd0000 xvssrln.h.w            XdXjXk
-74fd8000 xvssrln.w.d            XdXjXk
-74fe8000 xvssran.b.h            XdXjXk
-74ff0000 xvssran.h.w            XdXjXk
-74ff8000 xvssran.w.d            XdXjXk
-75008000 xvssrlrn.b.h           XdXjXk
-75010000 xvssrlrn.h.w           XdXjXk
-75018000 xvssrlrn.w.d           XdXjXk
-75028000 xvssrarn.b.h           XdXjXk
-75030000 xvssrarn.h.w           XdXjXk
-75038000 xvssrarn.w.d           XdXjXk
-75048000 xvssrln.bu.h           XdXjXk
-75050000 xvssrln.hu.w           XdXjXk
-75058000 xvssrln.wu.d           XdXjXk
-75068000 xvssran.bu.h           XdXjXk
-75070000 xvssran.hu.w           XdXjXk
-75078000 xvssran.wu.d           XdXjXk
-75088000 xvssrlrn.bu.h          XdXjXk
-75090000 xvssrlrn.hu.w          XdXjXk
-75098000 xvssrlrn.wu.d          XdXjXk
-750a8000 xvssrarn.bu.h          XdXjXk
-750b0000 xvssrarn.hu.w          XdXjXk
-750b8000 xvssrarn.wu.d          XdXjXk
-750c0000 xvbitclr.b             XdXjXk
-750c8000 xvbitclr.h             XdXjXk
-750d0000 xvbitclr.w             XdXjXk
-750d8000 xvbitclr.d             XdXjXk
-750e0000 xvbitset.b             XdXjXk
-750e8000 xvbitset.h             XdXjXk
-750f0000 xvbitset.w             XdXjXk
-750f8000 xvbitset.d             XdXjXk
-75100000 xvbitrev.b             XdXjXk
-75108000 xvbitrev.h             XdXjXk
-75110000 xvbitrev.w             XdXjXk
-75118000 xvbitrev.d             XdXjXk
-75160000 xvpackev.b             XdXjXk
-75168000 xvpackev.h             XdXjXk
-75170000 xvpackev.w             XdXjXk
-75178000 xvpackev.d             XdXjXk
-75180000 xvpackod.b             XdXjXk
-75188000 xvpackod.h             XdXjXk
-75190000 xvpackod.w             XdXjXk
-75198000 xvpackod.d             XdXjXk
-751a0000 xvilvl.b               XdXjXk
-751a8000 xvilvl.h               XdXjXk
-751b0000 xvilvl.w               XdXjXk
-751b8000 xvilvl.d               XdXjXk
-751c0000 xvilvh.b               XdXjXk
-751c8000 xvilvh.h               XdXjXk
-751d0000 xvilvh.w               XdXjXk
-751d8000 xvilvh.d               XdXjXk
-751e0000 xvpickev.b             XdXjXk
-751e8000 xvpickev.h             XdXjXk
-751f0000 xvpickev.w             XdXjXk
-751f8000 xvpickev.d             XdXjXk
-75200000 xvpickod.b             XdXjXk
-75208000 xvpickod.h             XdXjXk
-75210000 xvpickod.w             XdXjXk
-75218000 xvpickod.d             XdXjXk
-75220000 xvreplve.b             XdXjK           @qemu
-75228000 xvreplve.h             XdXjK           @qemu
-75230000 xvreplve.w             XdXjK           @qemu
-75238000 xvreplve.d             XdXjK           @qemu
-75260000 xvand.v                XdXjXk          @qemu
-75268000 xvor.v                 XdXjXk          @qemu
-75270000 xvxor.v                XdXjXk          @qemu
-75278000 xvnor.v                XdXjXk          @qemu
-75280000 xvandn.v               XdXjXk          @qemu
-75288000 xvorn.v                XdXjXk          @qemu
-752b0000 xvfrstp.b              XdXjXk
-752b8000 xvfrstp.h              XdXjXk
-752d0000 xvadd.q                XdXjXk
-752d8000 xvsub.q                XdXjXk
-752e0000 xvsigncov.b            XdXjXk
-752e8000 xvsigncov.h            XdXjXk
-752f0000 xvsigncov.w            XdXjXk
-752f8000 xvsigncov.d            XdXjXk
-75308000 xvfadd.s               XdXjXk
-75310000 xvfadd.d               XdXjXk
-75328000 xvfsub.s               XdXjXk
-75330000 xvfsub.d               XdXjXk
-75388000 xvfmul.s               XdXjXk
-75390000 xvfmul.d               XdXjXk
-753a8000 xvfdiv.s               XdXjXk
-753b0000 xvfdiv.d               XdXjXk
-753c8000 xvfmax.s               XdXjXk
-753d0000 xvfmax.d               XdXjXk
-753e8000 xvfmin.s               XdXjXk
-753f0000 xvfmin.d               XdXjXk
-75408000 xvfmaxa.s              XdXjXk
-75410000 xvfmaxa.d              XdXjXk
-75428000 xvfmina.s              XdXjXk
-75430000 xvfmina.d              XdXjXk
-75460000 xvfcvt.h.s             XdXjXk
-75468000 xvfcvt.s.d             XdXjXk
-75480000 xvffint.s.l            XdXjXk
-75498000 xvftint.w.d            XdXjXk
-754a0000 xvftintrm.w.d          XdXjXk
-754a8000 xvftintrp.w.d          XdXjXk
-754b0000 xvftintrz.w.d          XdXjXk
-754b8000 xvftintrne.w.d         XdXjXk
-757a8000 xvshuf.h               XdXjXk
-757b0000 xvshuf.w               XdXjXk
-757b8000 xvshuf.d               XdXjXk
-757d0000 xvperm.w               XdXjXk
-76800000 xvseqi.b               XdXjSk5         @qemu
-76808000 xvseqi.h               XdXjSk5         @qemu
-76810000 xvseqi.w               XdXjSk5         @qemu
-76818000 xvseqi.d               XdXjSk5         @qemu
-76820000 xvslei.b               XdXjSk5         @qemu
-76828000 xvslei.h               XdXjSk5         @qemu
-76830000 xvslei.w               XdXjSk5         @qemu
-76838000 xvslei.d               XdXjSk5         @qemu
-76840000 xvslei.bu              XdXjUk5         @qemu
-76848000 xvslei.hu              XdXjUk5         @qemu
-76850000 xvslei.wu              XdXjUk5         @qemu
-76858000 xvslei.du              XdXjUk5         @qemu
-76860000 xvslti.b               XdXjSk5         @qemu
-76868000 xvslti.h               XdXjSk5         @qemu
-76870000 xvslti.w               XdXjSk5         @qemu
-76878000 xvslti.d               XdXjSk5         @qemu
-76880000 xvslti.bu              XdXjUk5         @qemu
-76888000 xvslti.hu              XdXjUk5         @qemu
-76890000 xvslti.wu              XdXjUk5         @qemu
-76898000 xvslti.du              XdXjUk5         @qemu
-768a0000 xvaddi.bu              XdXjUk5         @qemu
-768a8000 xvaddi.hu              XdXjUk5         @qemu
-768b0000 xvaddi.wu              XdXjUk5         @qemu
-768b8000 xvaddi.du              XdXjUk5         @qemu
-768c0000 xvsubi.bu              XdXjUk5         @qemu
-768c8000 xvsubi.hu              XdXjUk5         @qemu
-768d0000 xvsubi.wu              XdXjUk5         @qemu
-768d8000 xvsubi.du              XdXjUk5         @qemu
-768e0000 xvbsll.v               XdXjUk5
-768e8000 xvbsrl.v               XdXjUk5
-76900000 xvmaxi.b               XdXjSk5         @qemu
-76908000 xvmaxi.h               XdXjSk5         @qemu
-76910000 xvmaxi.w               XdXjSk5         @qemu
-76918000 xvmaxi.d               XdXjSk5         @qemu
-76920000 xvmini.b               XdXjSk5         @qemu
-76928000 xvmini.h               XdXjSk5         @qemu
-76930000 xvmini.w               XdXjSk5         @qemu
-76938000 xvmini.d               XdXjSk5         @qemu
-76940000 xvmaxi.bu              XdXjUk5         @qemu
-76948000 xvmaxi.hu              XdXjUk5         @qemu
-76950000 xvmaxi.wu              XdXjUk5         @qemu
-76958000 xvmaxi.du              XdXjUk5         @qemu
-76960000 xvmini.bu              XdXjUk5         @qemu
-76968000 xvmini.hu              XdXjUk5         @qemu
-76970000 xvmini.wu              XdXjUk5         @qemu
-76978000 xvmini.du              XdXjUk5         @qemu
-769a0000 xvfrstpi.b             XdXjUk5
-769a8000 xvfrstpi.h             XdXjUk5
-769b8000 xvmepatmsk.v           XdUj5Uk5
-769c0000 xvclo.b                XdXj
-769c0400 xvclo.h                XdXj
-769c0800 xvclo.w                XdXj
-769c0c00 xvclo.d                XdXj
-769c1000 xvclz.b                XdXj
-769c1400 xvclz.h                XdXj
-769c1800 xvclz.w                XdXj
-769c1c00 xvclz.d                XdXj
-769c2000 xvpcnt.b               XdXj
-769c2400 xvpcnt.h               XdXj
-769c2800 xvpcnt.w               XdXj
-769c2c00 xvpcnt.d               XdXj
-769c3000 xvneg.b                XdXj            @qemu
-769c3400 xvneg.h                XdXj            @qemu
-769c3800 xvneg.w                XdXj            @qemu
-769c3c00 xvneg.d                XdXj            @qemu
-769c4000 xvmskltz.b             XdXj
-769c4400 xvmskltz.h             XdXj
-769c4800 xvmskltz.w             XdXj
-769c4c00 xvmskltz.d             XdXj
-769c5000 xvmskgez.b             XdXj
-769c6000 xvmsknz.b              XdXj
-769c9800 xvseteqz.v             CdXj
-769c9c00 xvsetnez.v             CdXj
-769ca000 xvsetanyeqz.b          CdXj
-769ca400 xvsetanyeqz.h          CdXj
-769ca800 xvsetanyeqz.w          CdXj
-769cac00 xvsetanyeqz.d          CdXj
-769cb000 xvsetallnez.b          CdXj
-769cb400 xvsetallnez.h          CdXj
-769cb800 xvsetallnez.w          CdXj
-769cbc00 xvsetallnez.d          CdXj
-769cc400 xvflogb.s              XdXj
-769cc800 xvflogb.d              XdXj
-769cd400 xvfclass.s             XdXj
-769cd800 xvfclass.d             XdXj
-769ce400 xvfsqrt.s              XdXj
-769ce800 xvfsqrt.d              XdXj
-769cf400 xvfrecip.s             XdXj
-769cf800 xvfrecip.d             XdXj
-769d0400 xvfrsqrt.s             XdXj
-769d0800 xvfrsqrt.d             XdXj
-769d1400 xvfrecipe.s            XdXj            @rev=1p10
-769d1800 xvfrecipe.d            XdXj            @rev=1p10
-769d2400 xvfrsqrte.s            XdXj            @rev=1p10
-769d2800 xvfrsqrte.d            XdXj            @rev=1p10
-769d3400 xvfrint.s              XdXj
-769d3800 xvfrint.d              XdXj
-769d4400 xvfrintrm.s            XdXj
-769d4800 xvfrintrm.d            XdXj
-769d5400 xvfrintrp.s            XdXj
-769d5800 xvfrintrp.d            XdXj
-769d6400 xvfrintrz.s            XdXj
-769d6800 xvfrintrz.d            XdXj
-769d7400 xvfrintrne.s           XdXj
-769d7800 xvfrintrne.d           XdXj
-769de800 xvfcvtl.s.h            XdXj
-769dec00 xvfcvth.s.h            XdXj
-769df000 xvfcvtl.d.s            XdXj
-769df400 xvfcvth.d.s            XdXj
-769e0000 xvffint.s.w            XdXj
-769e0400 xvffint.s.wu           XdXj
-769e0800 xvffint.d.l            XdXj
-769e0c00 xvffint.d.lu           XdXj
-769e1000 xvffintl.d.w           XdXj
-769e1400 xvffinth.d.w           XdXj
-769e3000 xvftint.w.s            XdXj
-769e3400 xvftint.l.d            XdXj
-769e3800 xvftintrm.w.s          XdXj
-769e3c00 xvftintrm.l.d          XdXj
-769e4000 xvftintrp.w.s          XdXj
-769e4400 xvftintrp.l.d          XdXj
-769e4800 xvftintrz.w.s          XdXj
-769e4c00 xvftintrz.l.d          XdXj
-769e5000 xvftintrne.w.s         XdXj
-769e5400 xvftintrne.l.d         XdXj
-769e5800 xvftint.wu.s           XdXj
-769e5c00 xvftint.lu.d           XdXj
-769e7000 xvftintrz.wu.s         XdXj
-769e7400 xvftintrz.lu.d         XdXj
-769e8000 xvftintl.l.s           XdXj
-769e8400 xvftinth.l.s           XdXj
-769e8800 xvftintrml.l.s         XdXj
-769e8c00 xvftintrmh.l.s         XdXj
-769e9000 xvftintrpl.l.s         XdXj
-769e9400 xvftintrph.l.s         XdXj
-769e9800 xvftintrzl.l.s         XdXj
-769e9c00 xvftintrzh.l.s         XdXj
-769ea000 xvftintrnel.l.s        XdXj
-769ea400 xvftintrneh.l.s        XdXj
-769ee000 xvexth.h.b             XdXj
-769ee400 xvexth.w.h             XdXj
-769ee800 xvexth.d.w             XdXj
-769eec00 xvexth.q.d             XdXj
-769ef000 xvexth.hu.bu           XdXj
-769ef400 xvexth.wu.hu           XdXj
-769ef800 xvexth.du.wu           XdXj
-769efc00 xvexth.qu.du           XdXj
-769f0000 xvreplgr2vr.b          XdJ             @qemu
-769f0400 xvreplgr2vr.h          XdJ             @qemu
-769f0800 xvreplgr2vr.w          XdJ             @qemu
-769f0c00 xvreplgr2vr.d          XdJ             @qemu
-769f1000 vext2xv.h.b            XdXj
-769f1400 vext2xv.w.b            XdXj
-769f1800 vext2xv.d.b            XdXj
-769f1c00 vext2xv.w.h            XdXj
-769f2000 vext2xv.d.h            XdXj
-769f2400 vext2xv.d.w            XdXj
-769f2800 vext2xv.hu.bu          XdXj
-769f2c00 vext2xv.wu.bu          XdXj
-769f3000 vext2xv.du.bu          XdXj
-769f3400 vext2xv.wu.hu          XdXj
-769f3800 vext2xv.du.hu          XdXj
-769f3c00 vext2xv.du.wu          XdXj
-76a02000 xvrotri.b              XdXjUk3        @qemu
-76a04000 xvrotri.h              XdXjUk4        @qemu
-76a08000 xvrotri.w              XdXjUk5        @qemu
-76a10000 xvrotri.d              XdXjUk6        @qemu
-76a42000 xvsrlri.b              XdXjUk3
-76a44000 xvsrlri.h              XdXjUk4
-76a48000 xvsrlri.w              XdXjUk5
-76a50000 xvsrlri.d              XdXjUk6
-76a82000 xvsrari.b              XdXjUk3
-76a84000 xvsrari.h              XdXjUk4
-76a88000 xvsrari.w              XdXjUk5
-76a90000 xvsrari.d              XdXjUk6
-76ebc000 xvinsgr2vr.w           XdJUk3          @qemu
-76ebe000 xvinsgr2vr.d           XdJUk2          @qemu
-76efc000 xvpickve2gr.w          DXjUk3          @qemu
-76efe000 xvpickve2gr.d          DXjUk2          @qemu
-76f3c000 xvpickve2gr.wu         DXjUk3          @qemu
-76f3e000 xvpickve2gr.du         DXjUk2          @qemu
-76f78000 xvrepl128vei.b         XdXjUk4         @qemu
-76f7c000 xvrepl128vei.h         XdXjUk3         @qemu
-76f7e000 xvrepl128vei.w         XdXjUk2         @qemu
-76f7f000 xvrepl128vei.d         XdXjUk1         @qemu
-76ffc000 xvinsve0.w             XdXjUk3
-76ffe000 xvinsve0.d             XdXjUk2
-7703c000 xvpickve.w             XdXjUk3
-7703e000 xvpickve.d             XdXjUk2
-77070000 xvreplve0.b            XdXj            @qemu
-77078000 xvreplve0.h            XdXj            @qemu
-7707c000 xvreplve0.w            XdXj            @qemu
-7707e000 xvreplve0.d            XdXj            @qemu
-7707f000 xvreplve0.q            XdXj            @qemu
-77082000 xvsllwil.h.b           XdXjUk3
-77084000 xvsllwil.w.h           XdXjUk4
-77088000 xvsllwil.d.w           XdXjUk5
-77090000 xvextl.q.d             XdXj
-770c2000 xvsllwil.hu.bu         XdXjUk3
-770c4000 xvsllwil.wu.hu         XdXjUk4
-770c8000 xvsllwil.du.wu         XdXjUk5
-770d0000 xvextl.qu.du           XdXj
-77102000 xvbitclri.b            XdXjUk3         @qemu
-77104000 xvbitclri.h            XdXjUk4         @qemu
-77108000 xvbitclri.w            XdXjUk5         @qemu
-77110000 xvbitclri.d            XdXjUk6         @qemu
-77142000 xvbitseti.b            XdXjUk3         @qemu
-77144000 xvbitseti.h            XdXjUk4         @qemu
-77148000 xvbitseti.w            XdXjUk5         @qemu
-77150000 xvbitseti.d            XdXjUk6         @qemu
-77182000 xvbitrevi.b            XdXjUk3         @qemu
-77184000 xvbitrevi.h            XdXjUk4         @qemu
-77188000 xvbitrevi.w            XdXjUk5         @qemu
-77190000 xvbitrevi.d            XdXjUk6         @qemu
-77242000 xvsat.b                XdXjUk3
-77244000 xvsat.h                XdXjUk4
-77248000 xvsat.w                XdXjUk5
-77250000 xvsat.d                XdXjUk6
-77282000 xvsat.bu               XdXjUk3
-77284000 xvsat.hu               XdXjUk4
-77288000 xvsat.wu               XdXjUk5
-77290000 xvsat.du               XdXjUk6
-772c2000 xvslli.b               XdXjUk3         @qemu
-772c4000 xvslli.h               XdXjUk4         @qemu
-772c8000 xvslli.w               XdXjUk5         @qemu
-772d0000 xvslli.d               XdXjUk6         @qemu
-77302000 xvsrli.b               XdXjUk3         @qemu
-77304000 xvsrli.h               XdXjUk4         @qemu
-77308000 xvsrli.w               XdXjUk5         @qemu
-77310000 xvsrli.d               XdXjUk6         @qemu
-77342000 xvsrai.b               XdXjUk3         @qemu
-77344000 xvsrai.h               XdXjUk4         @qemu
-77348000 xvsrai.w               XdXjUk5         @qemu
-77350000 xvsrai.d               XdXjUk6         @qemu
-77404000 xvsrlni.b.h            XdXjUk4
-77408000 xvsrlni.h.w            XdXjUk5
-77410000 xvsrlni.w.d            XdXjUk6
-77420000 xvsrlni.d.q            XdXjUk7
-77444000 xvsrlrni.b.h           XdXjUk4
-77448000 xvsrlrni.h.w           XdXjUk5
-77450000 xvsrlrni.w.d           XdXjUk6
-77460000 xvsrlrni.d.q           XdXjUk7
-77484000 xvssrlni.b.h           XdXjUk4
-77488000 xvssrlni.h.w           XdXjUk5
-77490000 xvssrlni.w.d           XdXjUk6
-774a0000 xvssrlni.d.q           XdXjUk7
-774c4000 xvssrlni.bu.h          XdXjUk4
-774c8000 xvssrlni.hu.w          XdXjUk5
-774d0000 xvssrlni.wu.d          XdXjUk6
-774e0000 xvssrlni.du.q          XdXjUk7
-77504000 xvssrlrni.b.h          XdXjUk4
-77508000 xvssrlrni.h.w          XdXjUk5
-77510000 xvssrlrni.w.d          XdXjUk6
-77520000 xvssrlrni.d.q          XdXjUk7
-77544000 xvssrlrni.bu.h         XdXjUk4
-77548000 xvssrlrni.hu.w         XdXjUk5
-77550000 xvssrlrni.wu.d         XdXjUk6
-77560000 xvssrlrni.du.q         XdXjUk7
-77584000 xvsrani.b.h            XdXjUk4
-77588000 xvsrani.h.w            XdXjUk5
-77590000 xvsrani.w.d            XdXjUk6
-775a0000 xvsrani.d.q            XdXjUk7
-775c4000 xvsrarni.b.h           XdXjUk4
-775c8000 xvsrarni.h.w           XdXjUk5
-775d0000 xvsrarni.w.d           XdXjUk6
-775e0000 xvsrarni.d.q           XdXjUk7
-77604000 xvssrani.b.h           XdXjUk4
-77608000 xvssrani.h.w           XdXjUk5
-77610000 xvssrani.w.d           XdXjUk6
-77620000 xvssrani.d.q           XdXjUk7
-77644000 xvssrani.bu.h          XdXjUk4
-77648000 xvssrani.hu.w          XdXjUk5
-77650000 xvssrani.wu.d          XdXjUk6
-77660000 xvssrani.du.q          XdXjUk7
-77684000 xvssrarni.b.h          XdXjUk4
-77688000 xvssrarni.h.w          XdXjUk5
-77690000 xvssrarni.w.d          XdXjUk6
-776a0000 xvssrarni.d.q          XdXjUk7
-776c4000 xvssrarni.bu.h         XdXjUk4
-776c8000 xvssrarni.hu.w         XdXjUk5
-776d0000 xvssrarni.wu.d         XdXjUk6
-776e0000 xvssrarni.du.q         XdXjUk7
-77800000 xvextrins.d            XdXjUk8
-77840000 xvextrins.w            XdXjUk8
-77880000 xvextrins.h            XdXjUk8
-778c0000 xvextrins.b            XdXjUk8
-77900000 xvshuf4i.b             XdXjUk8
-77940000 xvshuf4i.h             XdXjUk8
-77980000 xvshuf4i.w             XdXjUk8
-779c0000 xvshuf4i.d             XdXjUk8
-77c40000 xvbitseli.b            XdXjUk8         @qemu
-77d00000 xvandi.b               XdXjUk8         @qemu
-77d40000 xvori.b                XdXjUk8         @qemu
-77d80000 xvxori.b               XdXjUk8         @qemu
-77dc0000 xvnori.b               XdXjUk8         @qemu
-77e00000 xvldi                  XdSj13          @qemu
-77e40000 xvpermi.w              XdXjUk8
-77e80000 xvpermi.d              XdXjUk8
-77ec0000 xvpermi.q              XdXjUk8
+0a100000 xvfmadd.s              XdXjXkXa         @modify=Xd
+0a200000 xvfmadd.d              XdXjXkXa         @modify=Xd
+0a500000 xvfmsub.s              XdXjXkXa         @modify=Xd
+0a600000 xvfmsub.d              XdXjXkXa         @modify=Xd
+0a900000 xvfnmadd.s             XdXjXkXa         @modify=Xd
+0aa00000 xvfnmadd.d             XdXjXkXa         @modify=Xd
+0ad00000 xvfnmsub.s             XdXjXkXa         @modify=Xd
+0ae00000 xvfnmsub.d             XdXjXkXa         @modify=Xd
+0c900000 xvfcmp.caf.s           XdXjXk           @modify=Xd
+0c908000 xvfcmp.saf.s           XdXjXk           @modify=Xd
+0c910000 xvfcmp.clt.s           XdXjXk           @modify=Xd
+0c918000 xvfcmp.slt.s           XdXjXk           @modify=Xd
+0c920000 xvfcmp.ceq.s           XdXjXk           @modify=Xd
+0c928000 xvfcmp.seq.s           XdXjXk           @modify=Xd
+0c930000 xvfcmp.cle.s           XdXjXk           @modify=Xd
+0c938000 xvfcmp.sle.s           XdXjXk           @modify=Xd
+0c940000 xvfcmp.cun.s           XdXjXk           @modify=Xd
+0c948000 xvfcmp.sun.s           XdXjXk           @modify=Xd
+0c950000 xvfcmp.cult.s          XdXjXk           @modify=Xd
+0c958000 xvfcmp.sult.s          XdXjXk           @modify=Xd
+0c960000 xvfcmp.cueq.s          XdXjXk           @modify=Xd
+0c968000 xvfcmp.sueq.s          XdXjXk           @modify=Xd
+0c970000 xvfcmp.cule.s          XdXjXk           @modify=Xd
+0c978000 xvfcmp.sule.s          XdXjXk           @modify=Xd
+0c980000 xvfcmp.cne.s           XdXjXk           @modify=Xd
+0c988000 xvfcmp.sne.s           XdXjXk           @modify=Xd
+0c9a0000 xvfcmp.cor.s           XdXjXk           @modify=Xd
+0c9a8000 xvfcmp.sor.s           XdXjXk           @modify=Xd
+0c9c0000 xvfcmp.cune.s          XdXjXk           @modify=Xd
+0c9c8000 xvfcmp.sune.s          XdXjXk           @modify=Xd
+0ca00000 xvfcmp.caf.d           XdXjXk           @modify=Xd
+0ca08000 xvfcmp.saf.d           XdXjXk           @modify=Xd
+0ca10000 xvfcmp.clt.d           XdXjXk           @modify=Xd
+0ca18000 xvfcmp.slt.d           XdXjXk           @modify=Xd
+0ca20000 xvfcmp.ceq.d           XdXjXk           @modify=Xd
+0ca28000 xvfcmp.seq.d           XdXjXk           @modify=Xd
+0ca30000 xvfcmp.cle.d           XdXjXk           @modify=Xd
+0ca38000 xvfcmp.sle.d           XdXjXk           @modify=Xd
+0ca40000 xvfcmp.cun.d           XdXjXk           @modify=Xd
+0ca48000 xvfcmp.sun.d           XdXjXk           @modify=Xd
+0ca50000 xvfcmp.cult.d          XdXjXk           @modify=Xd
+0ca58000 xvfcmp.sult.d          XdXjXk           @modify=Xd
+0ca60000 xvfcmp.cueq.d          XdXjXk           @modify=Xd
+0ca68000 xvfcmp.sueq.d          XdXjXk           @modify=Xd
+0ca70000 xvfcmp.cule.d          XdXjXk           @modify=Xd
+0ca78000 xvfcmp.sule.d          XdXjXk           @modify=Xd
+0ca80000 xvfcmp.cne.d           XdXjXk           @modify=Xd
+0ca88000 xvfcmp.sne.d           XdXjXk           @modify=Xd
+0caa0000 xvfcmp.cor.d           XdXjXk           @modify=Xd
+0caa8000 xvfcmp.sor.d           XdXjXk           @modify=Xd
+0cac0000 xvfcmp.cune.d          XdXjXk           @modify=Xd
+0cac8000 xvfcmp.sune.d          XdXjXk           @modify=Xd
+0d200000 xvbitsel.v             XdXjXkXa         @qemu @modify=Xd
+0d600000 xvshuf.b               XdXjXkXa         @qemu @modify=Xd
+2c800000 xvld                   XdJSk12          @qemu @modify=Xd
+2cc00000 xvst                   XdJSk12          @qemu
+32100000 xvldrepl.d             XdJSk9           @orig_fmt=XdJSk9ps3 @qemu @modify=Xd
+32200000 xvldrepl.w             XdJSk10          @orig_fmt=XdJSk10ps2 @qemu @modify=Xd
+32400000 xvldrepl.h             XdJSk11          @orig_fmt=XdJSk11ps1 @qemu @modify=Xd
+32800000 xvldrepl.b             XdJSk12          @qemu
+33100000 xvstelm.d              XdJSk8Un2        @orig_fmt=XdJSk8ps3Un2 @qemu
+33200000 xvstelm.w              XdJSk8Un3        @orig_fmt=XdJSk8ps2Un3 @qemu
+33400000 xvstelm.h              XdJSk8Un4        @orig_fmt=XdJSk8ps1Un4 @qemu
+33800000 xvstelm.b              XdJSk8Un5        @qemu
+38480000 xvldx                  XdJK             @qemu @modify=Xd
+384c0000 xvstx                  XdJK             @qemu
+74000000 xvseq.b                XdXjXk           @qemu @modify=Xd
+74008000 xvseq.h                XdXjXk           @qemu @modify=Xd
+74010000 xvseq.w                XdXjXk           @qemu @modify=Xd
+74018000 xvseq.d                XdXjXk           @qemu @modify=Xd
+74020000 xvsle.b                XdXjXk           @qemu @modify=Xd
+74028000 xvsle.h                XdXjXk           @qemu @modify=Xd
+74030000 xvsle.w                XdXjXk           @qemu @modify=Xd @modify=Xd
+74038000 xvsle.d                XdXjXk           @qemu @modify=Xd
+74040000 xvsle.bu               XdXjXk           @qemu @modify=Xd
+74048000 xvsle.hu               XdXjXk           @qemu @modify=Xd
+74050000 xvsle.wu               XdXjXk           @qemu @modify=Xd
+74058000 xvsle.du               XdXjXk           @qemu @modify=Xd
+74060000 xvslt.b                XdXjXk           @qemu @modify=Xd
+74068000 xvslt.h                XdXjXk           @qemu @modify=Xd
+74070000 xvslt.w                XdXjXk           @qemu @modify=Xd
+74078000 xvslt.d                XdXjXk           @qemu @modify=Xd
+74080000 xvslt.bu               XdXjXk           @qemu @modify=Xd
+74088000 xvslt.hu               XdXjXk           @qemu @modify=Xd
+74090000 xvslt.wu               XdXjXk           @qemu @modify=Xd
+74098000 xvslt.du               XdXjXk           @qemu @modify=Xd
+740a0000 xvadd.b                XdXjXk           @qemu @modify=Xd
+740a8000 xvadd.h                XdXjXk           @qemu @modify=Xd
+740b0000 xvadd.w                XdXjXk           @qemu @modify=Xd
+740b8000 xvadd.d                XdXjXk           @qemu @modify=Xd
+740c0000 xvsub.b                XdXjXk           @qemu @modify=Xd
+740c8000 xvsub.h                XdXjXk           @qemu @modify=Xd
+740d0000 xvsub.w                XdXjXk           @qemu @modify=Xd
+740d8000 xvsub.d                XdXjXk           @qemu @modify=Xd
+741e0000 xvaddwev.h.b           XdXjXk           @modify=Xd
+741e8000 xvaddwev.w.h           XdXjXk           @modify=Xd
+741f0000 xvaddwev.d.w           XdXjXk           @modify=Xd
+741f8000 xvaddwev.q.d           XdXjXk           @modify=Xd
+74200000 xvsubwev.h.b           XdXjXk           @modify=Xd
+74208000 xvsubwev.w.h           XdXjXk           @modify=Xd
+74210000 xvsubwev.d.w           XdXjXk           @modify=Xd
+74218000 xvsubwev.q.d           XdXjXk           @modify=Xd
+74220000 xvaddwod.h.b           XdXjXk           @modify=Xd
+74228000 xvaddwod.w.h           XdXjXk           @modify=Xd
+74230000 xvaddwod.d.w           XdXjXk           @modify=Xd
+74238000 xvaddwod.q.d           XdXjXk           @modify=Xd
+74240000 xvsubwod.h.b           XdXjXk           @modify=Xd
+74248000 xvsubwod.w.h           XdXjXk           @modify=Xd
+74250000 xvsubwod.d.w           XdXjXk           @modify=Xd
+74258000 xvsubwod.q.d           XdXjXk           @modify=Xd
+742e0000 xvaddwev.h.bu          XdXjXk           @modify=Xd
+742e8000 xvaddwev.w.hu          XdXjXk           @modify=Xd
+742f0000 xvaddwev.d.wu          XdXjXk           @modify=Xd
+742f8000 xvaddwev.q.du          XdXjXk           @modify=Xd
+74300000 xvsubwev.h.bu          XdXjXk           @modify=Xd
+74308000 xvsubwev.w.hu          XdXjXk           @modify=Xd
+74310000 xvsubwev.d.wu          XdXjXk           @modify=Xd
+74318000 xvsubwev.q.du          XdXjXk           @modify=Xd
+74320000 xvaddwod.h.bu          XdXjXk           @modify=Xd
+74328000 xvaddwod.w.hu          XdXjXk           @modify=Xd
+74330000 xvaddwod.d.wu          XdXjXk           @modify=Xd
+74338000 xvaddwod.q.du          XdXjXk           @modify=Xd
+74340000 xvsubwod.h.bu          XdXjXk           @modify=Xd
+74348000 xvsubwod.w.hu          XdXjXk           @modify=Xd
+74350000 xvsubwod.d.wu          XdXjXk           @modify=Xd
+74358000 xvsubwod.q.du          XdXjXk           @modify=Xd
+743e0000 xvaddwev.h.bu.b        XdXjXk           @modify=Xd
+743e8000 xvaddwev.w.hu.h        XdXjXk           @modify=Xd
+743f0000 xvaddwev.d.wu.w        XdXjXk           @modify=Xd
+743f8000 xvaddwev.q.du.d        XdXjXk           @modify=Xd
+74400000 xvaddwod.h.bu.b        XdXjXk           @modify=Xd
+74408000 xvaddwod.w.hu.h        XdXjXk           @modify=Xd
+74410000 xvaddwod.d.wu.w        XdXjXk           @modify=Xd
+74418000 xvaddwod.q.du.d        XdXjXk           @modify=Xd
+74460000 xvsadd.b               XdXjXk           @qemu
+74468000 xvsadd.h               XdXjXk           @qemu
+74470000 xvsadd.w               XdXjXk           @qemu
+74478000 xvsadd.d               XdXjXk           @qemu
+74480000 xvssub.b               XdXjXk           @qemu
+74488000 xvssub.h               XdXjXk           @qemu
+74490000 xvssub.w               XdXjXk           @qemu
+74498000 xvssub.d               XdXjXk           @qemu
+744a0000 xvsadd.bu              XdXjXk           @qemu
+744a8000 xvsadd.hu              XdXjXk           @qemu
+744b0000 xvsadd.wu              XdXjXk           @qemu
+744b8000 xvsadd.du              XdXjXk           @qemu
+744c0000 xvssub.bu              XdXjXk           @qemu
+744c8000 xvssub.hu              XdXjXk           @qemu
+744d0000 xvssub.wu              XdXjXk           @qemu
+744d8000 xvssub.du              XdXjXk           @qemu
+74540000 xvhaddw.h.b            XdXjXk           @modify=Xd
+74548000 xvhaddw.w.h            XdXjXk           @modify=Xd
+74550000 xvhaddw.d.w            XdXjXk           @modify=Xd
+74558000 xvhaddw.q.d            XdXjXk           @modify=Xd
+74560000 xvhsubw.h.b            XdXjXk           @modify=Xd
+74568000 xvhsubw.w.h            XdXjXk           @modify=Xd
+74570000 xvhsubw.d.w            XdXjXk           @modify=Xd
+74578000 xvhsubw.q.d            XdXjXk           @modify=Xd
+74580000 xvhaddw.hu.bu          XdXjXk           @modify=Xd
+74588000 xvhaddw.wu.hu          XdXjXk           @modify=Xd
+74590000 xvhaddw.du.wu          XdXjXk           @modify=Xd
+74598000 xvhaddw.qu.du          XdXjXk           @modify=Xd
+745a0000 xvhsubw.hu.bu          XdXjXk           @modify=Xd
+745a8000 xvhsubw.wu.hu          XdXjXk           @modify=Xd
+745b0000 xvhsubw.du.wu          XdXjXk           @modify=Xd
+745b8000 xvhsubw.qu.du          XdXjXk           @modify=Xd
+745c0000 xvadda.b               XdXjXk           @modify=Xd
+745c8000 xvadda.h               XdXjXk           @modify=Xd
+745d0000 xvadda.w               XdXjXk           @modify=Xd
+745d8000 xvadda.d               XdXjXk           @modify=Xd
+74600000 xvabsd.b               XdXjXk           @modify=Xd
+74608000 xvabsd.h               XdXjXk           @modify=Xd
+74610000 xvabsd.w               XdXjXk           @modify=Xd
+74618000 xvabsd.d               XdXjXk           @modify=Xd
+74620000 xvabsd.bu              XdXjXk           @modify=Xd
+74628000 xvabsd.hu              XdXjXk           @modify=Xd
+74630000 xvabsd.wu              XdXjXk           @modify=Xd
+74638000 xvabsd.du              XdXjXk           @modify=Xd
+74640000 xvavg.b                XdXjXk           @modify=Xd
+74648000 xvavg.h                XdXjXk           @modify=Xd
+74650000 xvavg.w                XdXjXk           @modify=Xd
+74658000 xvavg.d                XdXjXk           @modify=Xd
+74660000 xvavg.bu               XdXjXk           @modify=Xd
+74668000 xvavg.hu               XdXjXk           @modify=Xd
+74670000 xvavg.wu               XdXjXk           @modify=Xd
+74678000 xvavg.du               XdXjXk           @modify=Xd
+74680000 xvavgr.b               XdXjXk           @modify=Xd
+74688000 xvavgr.h               XdXjXk           @modify=Xd
+74690000 xvavgr.w               XdXjXk           @modify=Xd
+74698000 xvavgr.d               XdXjXk           @modify=Xd
+746a0000 xvavgr.bu              XdXjXk           @modify=Xd
+746a8000 xvavgr.hu              XdXjXk           @modify=Xd
+746b0000 xvavgr.wu              XdXjXk           @modify=Xd
+746b8000 xvavgr.du              XdXjXk           @modify=Xd
+74700000 xvmax.b                XdXjXk           @qemu @modify=Xd
+74708000 xvmax.h                XdXjXk           @qemu @modify=Xd
+74710000 xvmax.w                XdXjXk           @qemu @modify=Xd
+74718000 xvmax.d                XdXjXk           @qemu @modify=Xd
+74720000 xvmin.b                XdXjXk           @qemu @modify=Xd
+74728000 xvmin.h                XdXjXk           @qemu @modify=Xd
+74730000 xvmin.w                XdXjXk           @qemu @modify=Xd
+74738000 xvmin.d                XdXjXk           @qemu @modify=Xd
+74740000 xvmax.bu               XdXjXk           @qemu @modify=Xd
+74748000 xvmax.hu               XdXjXk           @qemu @modify=Xd
+74750000 xvmax.wu               XdXjXk           @qemu @modify=Xd
+74758000 xvmax.du               XdXjXk           @qemu @modify=Xd
+74760000 xvmin.bu               XdXjXk           @qemu @modify=Xd
+74768000 xvmin.hu               XdXjXk           @qemu @modify=Xd
+74770000 xvmin.wu               XdXjXk           @qemu @modify=Xd
+74778000 xvmin.du               XdXjXk           @qemu @modify=Xd
+74840000 xvmul.b                XdXjXk           @qemu @modify=Xd
+74848000 xvmul.h                XdXjXk           @qemu @modify=Xd
+74850000 xvmul.w                XdXjXk           @qemu @modify=Xd
+74858000 xvmul.d                XdXjXk           @qemu @modify=Xd
+74860000 xvmuh.b                XdXjXk           @modify=Xd
+74868000 xvmuh.h                XdXjXk           @modify=Xd
+74870000 xvmuh.w                XdXjXk           @modify=Xd
+74878000 xvmuh.d                XdXjXk           @modify=Xd
+74880000 xvmuh.bu               XdXjXk           @modify=Xd
+74888000 xvmuh.hu               XdXjXk           @modify=Xd
+74890000 xvmuh.wu               XdXjXk           @modify=Xd
+74898000 xvmuh.du               XdXjXk           @modify=Xd
+74900000 xvmulwev.h.b           XdXjXk           @modify=Xd
+74908000 xvmulwev.w.h           XdXjXk           @modify=Xd
+74910000 xvmulwev.d.w           XdXjXk           @modify=Xd
+74918000 xvmulwev.q.d           XdXjXk           @modify=Xd
+74920000 xvmulwod.h.b           XdXjXk           @modify=Xd
+74928000 xvmulwod.w.h           XdXjXk           @modify=Xd
+74930000 xvmulwod.d.w           XdXjXk           @modify=Xd
+74938000 xvmulwod.q.d           XdXjXk           @modify=Xd
+74980000 xvmulwev.h.bu          XdXjXk           @modify=Xd
+74988000 xvmulwev.w.hu          XdXjXk           @modify=Xd
+74990000 xvmulwev.d.wu          XdXjXk           @modify=Xd
+74998000 xvmulwev.q.du          XdXjXk           @modify=Xd
+749a0000 xvmulwod.h.bu          XdXjXk           @modify=Xd
+749a8000 xvmulwod.w.hu          XdXjXk           @modify=Xd
+749b0000 xvmulwod.d.wu          XdXjXk           @modify=Xd
+749b8000 xvmulwod.q.du          XdXjXk           @modify=Xd
+74a00000 xvmulwev.h.bu.b        XdXjXk           @modify=Xd
+74a08000 xvmulwev.w.hu.h        XdXjXk           @modify=Xd
+74a10000 xvmulwev.d.wu.w        XdXjXk           @modify=Xd
+74a18000 xvmulwev.q.du.d        XdXjXk           @modify=Xd
+74a20000 xvmulwod.h.bu.b        XdXjXk           @modify=Xd
+74a28000 xvmulwod.w.hu.h        XdXjXk           @modify=Xd
+74a30000 xvmulwod.d.wu.w        XdXjXk           @modify=Xd
+74a38000 xvmulwod.q.du.d        XdXjXk           @modify=Xd
+74a80000 xvmadd.b               XdXjXk           @modify=Xd
+74a88000 xvmadd.h               XdXjXk           @modify=Xd
+74a90000 xvmadd.w               XdXjXk           @modify=Xd
+74a98000 xvmadd.d               XdXjXk           @modify=Xd
+74aa0000 xvmsub.b               XdXjXk           @modify=Xd
+74aa8000 xvmsub.h               XdXjXk           @modify=Xd
+74ab0000 xvmsub.w               XdXjXk           @modify=Xd
+74ab8000 xvmsub.d               XdXjXk           @modify=Xd
+74ac0000 xvmaddwev.h.b          XdXjXk           @modify=Xd
+74ac8000 xvmaddwev.w.h          XdXjXk           @modify=Xd
+74ad0000 xvmaddwev.d.w          XdXjXk           @modify=Xd
+74ad8000 xvmaddwev.q.d          XdXjXk           @modify=Xd
+74ae0000 xvmaddwod.h.b          XdXjXk           @modify=Xd
+74ae8000 xvmaddwod.w.h          XdXjXk           @modify=Xd
+74af0000 xvmaddwod.d.w          XdXjXk           @modify=Xd
+74af8000 xvmaddwod.q.d          XdXjXk           @modify=Xd
+74b40000 xvmaddwev.h.bu         XdXjXk           @modify=Xd
+74b48000 xvmaddwev.w.hu         XdXjXk           @modify=Xd
+74b50000 xvmaddwev.d.wu         XdXjXk           @modify=Xd
+74b58000 xvmaddwev.q.du         XdXjXk           @modify=Xd
+74b60000 xvmaddwod.h.bu         XdXjXk           @modify=Xd
+74b68000 xvmaddwod.w.hu         XdXjXk           @modify=Xd
+74b70000 xvmaddwod.d.wu         XdXjXk           @modify=Xd
+74b78000 xvmaddwod.q.du         XdXjXk           @modify=Xd
+74bc0000 xvmaddwev.h.bu.b       XdXjXk           @modify=Xd
+74bc8000 xvmaddwev.w.hu.h       XdXjXk           @modify=Xd
+74bd0000 xvmaddwev.d.wu.w       XdXjXk           @modify=Xd
+74bd8000 xvmaddwev.q.du.d       XdXjXk           @modify=Xd
+74be0000 xvmaddwod.h.bu.b       XdXjXk           @modify=Xd
+74be8000 xvmaddwod.w.hu.h       XdXjXk           @modify=Xd
+74bf0000 xvmaddwod.d.wu.w       XdXjXk           @modify=Xd
+74bf8000 xvmaddwod.q.du.d       XdXjXk           @modify=Xd
+74e00000 xvdiv.b                XdXjXk           @modify=Xd
+74e08000 xvdiv.h                XdXjXk           @modify=Xd
+74e10000 xvdiv.w                XdXjXk           @modify=Xd
+74e18000 xvdiv.d                XdXjXk           @modify=Xd
+74e20000 xvmod.b                XdXjXk           @modify=Xd
+74e28000 xvmod.h                XdXjXk           @modify=Xd
+74e30000 xvmod.w                XdXjXk           @modify=Xd
+74e38000 xvmod.d                XdXjXk           @modify=Xd
+74e40000 xvdiv.bu               XdXjXk           @modify=Xd
+74e48000 xvdiv.hu               XdXjXk           @modify=Xd
+74e50000 xvdiv.wu               XdXjXk           @modify=Xd
+74e58000 xvdiv.du               XdXjXk           @modify=Xd
+74e60000 xvmod.bu               XdXjXk           @modify=Xd
+74e68000 xvmod.hu               XdXjXk           @modify=Xd
+74e70000 xvmod.wu               XdXjXk           @modify=Xd
+74e78000 xvmod.du               XdXjXk           @modify=Xd
+74e80000 xvsll.b                XdXjXk           @qemu
+74e88000 xvsll.h                XdXjXk           @qemu
+74e90000 xvsll.w                XdXjXk           @qemu
+74e98000 xvsll.d                XdXjXk           @qemu
+74ea0000 xvsrl.b                XdXjXk           @qemu
+74ea8000 xvsrl.h                XdXjXk           @qemu
+74eb0000 xvsrl.w                XdXjXk           @qemu
+74eb8000 xvsrl.d                XdXjXk           @qemu
+74ec0000 xvsra.b                XdXjXk           @qemu
+74ec8000 xvsra.h                XdXjXk           @qemu
+74ed0000 xvsra.w                XdXjXk           @qemu
+74ed8000 xvsra.d                XdXjXk           @qemu
+74ee0000 xvrotr.b               XdXjXk           @qemu
+74ee8000 xvrotr.h               XdXjXk           @qemu
+74ef0000 xvrotr.w               XdXjXk           @qemu
+74ef8000 xvrotr.d               XdXjXk           @qemu
+74f00000 xvsrlr.b               XdXjXk           @modify=Xd
+74f08000 xvsrlr.h               XdXjXk           @modify=Xd
+74f10000 xvsrlr.w               XdXjXk           @modify=Xd
+74f18000 xvsrlr.d               XdXjXk           @modify=Xd
+74f20000 xvsrar.b               XdXjXk           @modify=Xd
+74f28000 xvsrar.h               XdXjXk           @modify=Xd
+74f30000 xvsrar.w               XdXjXk           @modify=Xd
+74f38000 xvsrar.d               XdXjXk           @modify=Xd
+74f48000 xvsrln.b.h             XdXjXk           @modify=Xd
+74f50000 xvsrln.h.w             XdXjXk           @modify=Xd
+74f58000 xvsrln.w.d             XdXjXk           @modify=Xd
+74f68000 xvsran.b.h             XdXjXk           @modify=Xd
+74f70000 xvsran.h.w             XdXjXk           @modify=Xd
+74f78000 xvsran.w.d             XdXjXk           @modify=Xd
+74f88000 xvsrlrn.b.h            XdXjXk           @modify=Xd
+74f90000 xvsrlrn.h.w            XdXjXk           @modify=Xd
+74f98000 xvsrlrn.w.d            XdXjXk           @modify=Xd
+74fa8000 xvsrarn.b.h            XdXjXk           @modify=Xd
+74fb0000 xvsrarn.h.w            XdXjXk           @modify=Xd
+74fb8000 xvsrarn.w.d            XdXjXk           @modify=Xd
+74fc8000 xvssrln.b.h            XdXjXk           @modify=Xd
+74fd0000 xvssrln.h.w            XdXjXk           @modify=Xd
+74fd8000 xvssrln.w.d            XdXjXk           @modify=Xd
+74fe8000 xvssran.b.h            XdXjXk           @modify=Xd
+74ff0000 xvssran.h.w            XdXjXk           @modify=Xd
+74ff8000 xvssran.w.d            XdXjXk           @modify=Xd
+75008000 xvssrlrn.b.h           XdXjXk           @modify=Xd
+75010000 xvssrlrn.h.w           XdXjXk           @modify=Xd
+75018000 xvssrlrn.w.d           XdXjXk           @modify=Xd
+75028000 xvssrarn.b.h           XdXjXk           @modify=Xd
+75030000 xvssrarn.h.w           XdXjXk           @modify=Xd
+75038000 xvssrarn.w.d           XdXjXk           @modify=Xd
+75048000 xvssrln.bu.h           XdXjXk           @modify=Xd
+75050000 xvssrln.hu.w           XdXjXk           @modify=Xd
+75058000 xvssrln.wu.d           XdXjXk           @modify=Xd
+75068000 xvssran.bu.h           XdXjXk           @modify=Xd
+75070000 xvssran.hu.w           XdXjXk           @modify=Xd
+75078000 xvssran.wu.d           XdXjXk           @modify=Xd
+75088000 xvssrlrn.bu.h          XdXjXk           @modify=Xd
+75090000 xvssrlrn.hu.w          XdXjXk           @modify=Xd
+75098000 xvssrlrn.wu.d          XdXjXk           @modify=Xd
+750a8000 xvssrarn.bu.h          XdXjXk           @modify=Xd
+750b0000 xvssrarn.hu.w          XdXjXk           @modify=Xd
+750b8000 xvssrarn.wu.d          XdXjXk           @modify=Xd
+750c0000 xvbitclr.b             XdXjXk           @modify=Xd
+750c8000 xvbitclr.h             XdXjXk           @modify=Xd
+750d0000 xvbitclr.w             XdXjXk           @modify=Xd
+750d8000 xvbitclr.d             XdXjXk           @modify=Xd
+750e0000 xvbitset.b             XdXjXk           @modify=Xd
+750e8000 xvbitset.h             XdXjXk           @modify=Xd
+750f0000 xvbitset.w             XdXjXk           @modify=Xd
+750f8000 xvbitset.d             XdXjXk           @modify=Xd
+75100000 xvbitrev.b             XdXjXk           @modify=Xd
+75108000 xvbitrev.h             XdXjXk           @modify=Xd
+75110000 xvbitrev.w             XdXjXk           @modify=Xd
+75118000 xvbitrev.d             XdXjXk           @modify=Xd
+75160000 xvpackev.b             XdXjXk           @modify=Xd
+75168000 xvpackev.h             XdXjXk           @modify=Xd
+75170000 xvpackev.w             XdXjXk           @modify=Xd
+75178000 xvpackev.d             XdXjXk           @modify=Xd
+75180000 xvpackod.b             XdXjXk           @modify=Xd
+75188000 xvpackod.h             XdXjXk           @modify=Xd
+75190000 xvpackod.w             XdXjXk           @modify=Xd
+75198000 xvpackod.d             XdXjXk           @modify=Xd
+751a0000 xvilvl.b               XdXjXk           @modify=Xd
+751a8000 xvilvl.h               XdXjXk           @modify=Xd
+751b0000 xvilvl.w               XdXjXk           @modify=Xd
+751b8000 xvilvl.d               XdXjXk           @modify=Xd
+751c0000 xvilvh.b               XdXjXk           @modify=Xd
+751c8000 xvilvh.h               XdXjXk           @modify=Xd
+751d0000 xvilvh.w               XdXjXk           @modify=Xd
+751d8000 xvilvh.d               XdXjXk           @modify=Xd
+751e0000 xvpickev.b             XdXjXk           @modify=Xd
+751e8000 xvpickev.h             XdXjXk           @modify=Xd
+751f0000 xvpickev.w             XdXjXk           @modify=Xd
+751f8000 xvpickev.d             XdXjXk           @modify=Xd
+75200000 xvpickod.b             XdXjXk           @modify=Xd
+75208000 xvpickod.h             XdXjXk           @modify=Xd
+75210000 xvpickod.w             XdXjXk           @modify=Xd
+75218000 xvpickod.d             XdXjXk           @modify=Xd
+75220000 xvreplve.b             XdXjK            @qemu @modify=Xd
+75228000 xvreplve.h             XdXjK            @qemu @modify=Xd
+75230000 xvreplve.w             XdXjK            @qemu @modify=Xd
+75238000 xvreplve.d             XdXjK            @qemu @modify=Xd
+75260000 xvand.v                XdXjXk           @qemu @modify=Xd
+75268000 xvor.v                 XdXjXk           @qemu @modify=Xd
+75270000 xvxor.v                XdXjXk           @qemu @modify=Xd
+75278000 xvnor.v                XdXjXk           @qemu @modify=Xd
+75280000 xvandn.v               XdXjXk           @qemu @modify=Xd
+75288000 xvorn.v                XdXjXk           @qemu @modify=Xd
+752b0000 xvfrstp.b              XdXjXk           @modify=Xd
+752b8000 xvfrstp.h              XdXjXk           @modify=Xd
+752d0000 xvadd.q                XdXjXk           @modify=Xd
+752d8000 xvsub.q                XdXjXk           @modify=Xd
+752e0000 xvsigncov.b            XdXjXk           @modify=Xd
+752e8000 xvsigncov.h            XdXjXk           @modify=Xd
+752f0000 xvsigncov.w            XdXjXk           @modify=Xd
+752f8000 xvsigncov.d            XdXjXk           @modify=Xd
+75308000 xvfadd.s               XdXjXk           @modify=Xd
+75310000 xvfadd.d               XdXjXk           @modify=Xd
+75328000 xvfsub.s               XdXjXk           @modify=Xd
+75330000 xvfsub.d               XdXjXk           @modify=Xd
+75388000 xvfmul.s               XdXjXk           @modify=Xd
+75390000 xvfmul.d               XdXjXk           @modify=Xd
+753a8000 xvfdiv.s               XdXjXk           @modify=Xd
+753b0000 xvfdiv.d               XdXjXk           @modify=Xd
+753c8000 xvfmax.s               XdXjXk           @modify=Xd
+753d0000 xvfmax.d               XdXjXk           @modify=Xd
+753e8000 xvfmin.s               XdXjXk           @modify=Xd
+753f0000 xvfmin.d               XdXjXk           @modify=Xd
+75408000 xvfmaxa.s              XdXjXk           @modify=Xd
+75410000 xvfmaxa.d              XdXjXk           @modify=Xd
+75428000 xvfmina.s              XdXjXk           @modify=Xd
+75430000 xvfmina.d              XdXjXk           @modify=Xd
+75460000 xvfcvt.h.s             XdXjXk           @modify=Xd
+75468000 xvfcvt.s.d             XdXjXk           @modify=Xd
+75480000 xvffint.s.l            XdXjXk           @modify=Xd
+75498000 xvftint.w.d            XdXjXk           @modify=Xd
+754a0000 xvftintrm.w.d          XdXjXk           @modify=Xd
+754a8000 xvftintrp.w.d          XdXjXk           @modify=Xd
+754b0000 xvftintrz.w.d          XdXjXk           @modify=Xd
+754b8000 xvftintrne.w.d         XdXjXk           @modify=Xd
+757a8000 xvshuf.h               XdXjXk           @modify=Xd
+757b0000 xvshuf.w               XdXjXk           @modify=Xd
+757b8000 xvshuf.d               XdXjXk           @modify=Xd
+757d0000 xvperm.w               XdXjXk           @modify=Xd
+76800000 xvseqi.b               XdXjSk5          @qemu @modify=Xd
+76808000 xvseqi.h               XdXjSk5          @qemu @modify=Xd
+76810000 xvseqi.w               XdXjSk5          @qemu @modify=Xd
+76818000 xvseqi.d               XdXjSk5          @qemu @modify=Xd
+76820000 xvslei.b               XdXjSk5          @qemu @modify=Xd
+76828000 xvslei.h               XdXjSk5          @qemu @modify=Xd
+76830000 xvslei.w               XdXjSk5          @qemu @modify=Xd
+76838000 xvslei.d               XdXjSk5          @qemu @modify=Xd
+76840000 xvslei.bu              XdXjUk5          @qemu @modify=Xd
+76848000 xvslei.hu              XdXjUk5          @qemu @modify=Xd
+76850000 xvslei.wu              XdXjUk5          @qemu @modify=Xd
+76858000 xvslei.du              XdXjUk5          @qemu @modify=Xd
+76860000 xvslti.b               XdXjSk5          @qemu @modify=Xd
+76868000 xvslti.h               XdXjSk5          @qemu @modify=Xd
+76870000 xvslti.w               XdXjSk5          @qemu @modify=Xd
+76878000 xvslti.d               XdXjSk5          @qemu @modify=Xd
+76880000 xvslti.bu              XdXjUk5          @qemu @modify=Xd
+76888000 xvslti.hu              XdXjUk5          @qemu @modify=Xd
+76890000 xvslti.wu              XdXjUk5          @qemu @modify=Xd
+76898000 xvslti.du              XdXjUk5          @qemu @modify=Xd
+768a0000 xvaddi.bu              XdXjUk5          @qemu @modify=Xd
+768a8000 xvaddi.hu              XdXjUk5          @qemu @modify=Xd
+768b0000 xvaddi.wu              XdXjUk5          @qemu @modify=Xd
+768b8000 xvaddi.du              XdXjUk5          @qemu @modify=Xd
+768c0000 xvsubi.bu              XdXjUk5          @qemu @modify=Xd
+768c8000 xvsubi.hu              XdXjUk5          @qemu @modify=Xd
+768d0000 xvsubi.wu              XdXjUk5          @qemu @modify=Xd
+768d8000 xvsubi.du              XdXjUk5          @qemu @modify=Xd
+768e0000 xvbsll.v               XdXjUk5          @modify=Xd
+768e8000 xvbsrl.v               XdXjUk5          @modify=Xd
+76900000 xvmaxi.b               XdXjSk5          @qemu @modify=Xd
+76908000 xvmaxi.h               XdXjSk5          @qemu @modify=Xd
+76910000 xvmaxi.w               XdXjSk5          @qemu @modify=Xd
+76918000 xvmaxi.d               XdXjSk5          @qemu @modify=Xd
+76920000 xvmini.b               XdXjSk5          @qemu @modify=Xd
+76928000 xvmini.h               XdXjSk5          @qemu @modify=Xd
+76930000 xvmini.w               XdXjSk5          @qemu @modify=Xd
+76938000 xvmini.d               XdXjSk5          @qemu @modify=Xd
+76940000 xvmaxi.bu              XdXjUk5          @qemu @modify=Xd
+76948000 xvmaxi.hu              XdXjUk5          @qemu @modify=Xd
+76950000 xvmaxi.wu              XdXjUk5          @qemu @modify=Xd
+76958000 xvmaxi.du              XdXjUk5          @qemu @modify=Xd
+76960000 xvmini.bu              XdXjUk5          @qemu @modify=Xd
+76968000 xvmini.hu              XdXjUk5          @qemu @modify=Xd
+76970000 xvmini.wu              XdXjUk5          @qemu @modify=Xd
+76978000 xvmini.du              XdXjUk5          @qemu @modify=Xd
+769a0000 xvfrstpi.b             XdXjUk5          @modify=Xd
+769a8000 xvfrstpi.h             XdXjUk5          @modify=Xd
+769b8000 xvmepatmsk.v           XdUj5Uk5         @modify=Xd
+769c0000 xvclo.b                XdXj             @modify=Xd
+769c0400 xvclo.h                XdXj             @modify=Xd
+769c0800 xvclo.w                XdXj             @modify=Xd
+769c0c00 xvclo.d                XdXj             @modify=Xd
+769c1000 xvclz.b                XdXj             @modify=Xd
+769c1400 xvclz.h                XdXj             @modify=Xd
+769c1800 xvclz.w                XdXj             @modify=Xd
+769c1c00 xvclz.d                XdXj             @modify=Xd
+769c2000 xvpcnt.b               XdXj             @modify=Xd
+769c2400 xvpcnt.h               XdXj             @modify=Xd
+769c2800 xvpcnt.w               XdXj             @modify=Xd
+769c2c00 xvpcnt.d               XdXj             @modify=Xd
+769c3000 xvneg.b                XdXj             @qemu @modify=Xd
+769c3400 xvneg.h                XdXj             @qemu @modify=Xd
+769c3800 xvneg.w                XdXj             @qemu @modify=Xd
+769c3c00 xvneg.d                XdXj             @qemu @modify=Xd
+769c4000 xvmskltz.b             XdXj             @modify=Xd
+769c4400 xvmskltz.h             XdXj             @modify=Xd
+769c4800 xvmskltz.w             XdXj             @modify=Xd
+769c4c00 xvmskltz.d             XdXj             @modify=Xd
+769c5000 xvmskgez.b             XdXj             @modify=Xd
+769c6000 xvmsknz.b              XdXj             @modify=Xd
+769c9800 xvseteqz.v             CdXj             @modify=Cd
+769c9c00 xvsetnez.v             CdXj             @modify=Cd
+769ca000 xvsetanyeqz.b          CdXj             @modify=Cd
+769ca400 xvsetanyeqz.h          CdXj             @modify=Cd
+769ca800 xvsetanyeqz.w          CdXj             @modify=Cd
+769cac00 xvsetanyeqz.d          CdXj             @modify=Cd
+769cb000 xvsetallnez.b          CdXj             @modify=Cd
+769cb400 xvsetallnez.h          CdXj             @modify=Cd
+769cb800 xvsetallnez.w          CdXj             @modify=Cd
+769cbc00 xvsetallnez.d          CdXj             @modify=Cd
+769cc400 xvflogb.s              XdXj             @modify=Xd
+769cc800 xvflogb.d              XdXj             @modify=Xd
+769cd400 xvfclass.s             XdXj             @modify=Xd
+769cd800 xvfclass.d             XdXj             @modify=Xd
+769ce400 xvfsqrt.s              XdXj             @modify=Xd
+769ce800 xvfsqrt.d              XdXj             @modify=Xd
+769cf400 xvfrecip.s             XdXj             @modify=Xd
+769cf800 xvfrecip.d             XdXj             @modify=Xd
+769d0400 xvfrsqrt.s             XdXj             @modify=Xd
+769d0800 xvfrsqrt.d             XdXj             @modify=Xd
+769d1400 xvfrecipe.s            XdXj             @rev=1p10 @modify=Xd
+769d1800 xvfrecipe.d            XdXj             @rev=1p10 @modify=Xd
+769d2400 xvfrsqrte.s            XdXj             @rev=1p10 @modify=Xd
+769d2800 xvfrsqrte.d            XdXj             @rev=1p10 @modify=Xd
+769d3400 xvfrint.s              XdXj             @modify=Xd
+769d3800 xvfrint.d              XdXj             @modify=Xd
+769d4400 xvfrintrm.s            XdXj             @modify=Xd
+769d4800 xvfrintrm.d            XdXj             @modify=Xd
+769d5400 xvfrintrp.s            XdXj             @modify=Xd
+769d5800 xvfrintrp.d            XdXj             @modify=Xd
+769d6400 xvfrintrz.s            XdXj             @modify=Xd
+769d6800 xvfrintrz.d            XdXj             @modify=Xd
+769d7400 xvfrintrne.s           XdXj             @modify=Xd
+769d7800 xvfrintrne.d           XdXj             @modify=Xd
+769de800 xvfcvtl.s.h            XdXj             @modify=Xd
+769dec00 xvfcvth.s.h            XdXj             @modify=Xd
+769df000 xvfcvtl.d.s            XdXj             @modify=Xd
+769df400 xvfcvth.d.s            XdXj             @modify=Xd
+769e0000 xvffint.s.w            XdXj             @modify=Xd
+769e0400 xvffint.s.wu           XdXj             @modify=Xd
+769e0800 xvffint.d.l            XdXj             @modify=Xd
+769e0c00 xvffint.d.lu           XdXj             @modify=Xd
+769e1000 xvffintl.d.w           XdXj             @modify=Xd
+769e1400 xvffinth.d.w           XdXj             @modify=Xd
+769e3000 xvftint.w.s            XdXj             @modify=Xd
+769e3400 xvftint.l.d            XdXj             @modify=Xd
+769e3800 xvftintrm.w.s          XdXj             @modify=Xd
+769e3c00 xvftintrm.l.d          XdXj             @modify=Xd
+769e4000 xvftintrp.w.s          XdXj             @modify=Xd
+769e4400 xvftintrp.l.d          XdXj             @modify=Xd
+769e4800 xvftintrz.w.s          XdXj             @modify=Xd
+769e4c00 xvftintrz.l.d          XdXj             @modify=Xd
+769e5000 xvftintrne.w.s         XdXj             @modify=Xd
+769e5400 xvftintrne.l.d         XdXj             @modify=Xd
+769e5800 xvftint.wu.s           XdXj             @modify=Xd
+769e5c00 xvftint.lu.d           XdXj             @modify=Xd
+769e7000 xvftintrz.wu.s         XdXj             @modify=Xd
+769e7400 xvftintrz.lu.d         XdXj             @modify=Xd
+769e8000 xvftintl.l.s           XdXj             @modify=Xd
+769e8400 xvftinth.l.s           XdXj             @modify=Xd
+769e8800 xvftintrml.l.s         XdXj             @modify=Xd
+769e8c00 xvftintrmh.l.s         XdXj             @modify=Xd
+769e9000 xvftintrpl.l.s         XdXj             @modify=Xd
+769e9400 xvftintrph.l.s         XdXj             @modify=Xd
+769e9800 xvftintrzl.l.s         XdXj             @modify=Xd
+769e9c00 xvftintrzh.l.s         XdXj             @modify=Xd
+769ea000 xvftintrnel.l.s        XdXj             @modify=Xd
+769ea400 xvftintrneh.l.s        XdXj             @modify=Xd
+769ee000 xvexth.h.b             XdXj             @modify=Xd
+769ee400 xvexth.w.h             XdXj             @modify=Xd
+769ee800 xvexth.d.w             XdXj             @modify=Xd
+769eec00 xvexth.q.d             XdXj             @modify=Xd
+769ef000 xvexth.hu.bu           XdXj             @modify=Xd
+769ef400 xvexth.wu.hu           XdXj             @modify=Xd
+769ef800 xvexth.du.wu           XdXj             @modify=Xd
+769efc00 xvexth.qu.du           XdXj             @modify=Xd
+769f0000 xvreplgr2vr.b          XdJ              @qemu @modify=Xd
+769f0400 xvreplgr2vr.h          XdJ              @qemu @modify=Xd
+769f0800 xvreplgr2vr.w          XdJ              @qemu @modify=Xd
+769f0c00 xvreplgr2vr.d          XdJ              @qemu @modify=Xd
+769f1000 vext2xv.h.b            XdXj             @modify=Xd
+769f1400 vext2xv.w.b            XdXj             @modify=Xd
+769f1800 vext2xv.d.b            XdXj             @modify=Xd
+769f1c00 vext2xv.w.h            XdXj             @modify=Xd
+769f2000 vext2xv.d.h            XdXj             @modify=Xd
+769f2400 vext2xv.d.w            XdXj             @modify=Xd
+769f2800 vext2xv.hu.bu          XdXj             @modify=Xd
+769f2c00 vext2xv.wu.bu          XdXj             @modify=Xd
+769f3000 vext2xv.du.bu          XdXj             @modify=Xd
+769f3400 vext2xv.wu.hu          XdXj             @modify=Xd
+769f3800 vext2xv.du.hu          XdXj             @modify=Xd
+769f3c00 vext2xv.du.wu          XdXj             @modify=Xd
+76a02000 xvrotri.b              XdXjUk3          @qemu @modify=Xd
+76a04000 xvrotri.h              XdXjUk4          @qemu @modify=Xd
+76a08000 xvrotri.w              XdXjUk5          @qemu @modify=Xd
+76a10000 xvrotri.d              XdXjUk6          @qemu @modify=Xd
+76a42000 xvsrlri.b              XdXjUk3          @modify=Xd
+76a44000 xvsrlri.h              XdXjUk4          @modify=Xd
+76a48000 xvsrlri.w              XdXjUk5          @modify=Xd
+76a50000 xvsrlri.d              XdXjUk6          @modify=Xd
+76a82000 xvsrari.b              XdXjUk3          @modify=Xd
+76a84000 xvsrari.h              XdXjUk4          @modify=Xd
+76a88000 xvsrari.w              XdXjUk5          @modify=Xd
+76a90000 xvsrari.d              XdXjUk6          @modify=Xd
+76ebc000 xvinsgr2vr.w           XdJUk3           @qemu @modify=Xd
+76ebe000 xvinsgr2vr.d           XdJUk2           @qemu @modify=Xd
+76efc000 xvpickve2gr.w          DXjUk3           @qemu @modify=Xd
+76efe000 xvpickve2gr.d          DXjUk2           @qemu @modify=Xd
+76f3c000 xvpickve2gr.wu         DXjUk3           @qemu @modify=Xd
+76f3e000 xvpickve2gr.du         DXjUk2           @qemu @modify=Xd
+76f78000 xvrepl128vei.b         XdXjUk4          @qemu @modify=Xd
+76f7c000 xvrepl128vei.h         XdXjUk3          @qemu @modify=Xd
+76f7e000 xvrepl128vei.w         XdXjUk2          @qemu @modify=Xd
+76f7f000 xvrepl128vei.d         XdXjUk1          @qemu @modify=Xd
+76ffc000 xvinsve0.w             XdXjUk3          @modify=Xd
+76ffe000 xvinsve0.d             XdXjUk2          @modify=Xd
+7703c000 xvpickve.w             XdXjUk3          @modify=Xd
+7703e000 xvpickve.d             XdXjUk2          @modify=Xd
+77070000 xvreplve0.b            XdXj             @qemu @modify=Xd
+77078000 xvreplve0.h            XdXj             @qemu @modify=Xd
+7707c000 xvreplve0.w            XdXj             @qemu @modify=Xd
+7707e000 xvreplve0.d            XdXj             @qemu @modify=Xd
+7707f000 xvreplve0.q            XdXj             @qemu @modify=Xd
+77082000 xvsllwil.h.b           XdXjUk3          @modify=Xd
+77084000 xvsllwil.w.h           XdXjUk4          @modify=Xd
+77088000 xvsllwil.d.w           XdXjUk5          @modify=Xd
+77090000 xvextl.q.d             XdXj             @modify=Xd
+770c2000 xvsllwil.hu.bu         XdXjUk3          @modify=Xd
+770c4000 xvsllwil.wu.hu         XdXjUk4          @modify=Xd
+770c8000 xvsllwil.du.wu         XdXjUk5          @modify=Xd
+770d0000 xvextl.qu.du           XdXj             @modify=Xd
+77102000 xvbitclri.b            XdXjUk3          @qemu @modify=Xd
+77104000 xvbitclri.h            XdXjUk4          @qemu @modify=Xd
+77108000 xvbitclri.w            XdXjUk5          @qemu @modify=Xd
+77110000 xvbitclri.d            XdXjUk6          @qemu @modify=Xd
+77142000 xvbitseti.b            XdXjUk3          @qemu @modify=Xd
+77144000 xvbitseti.h            XdXjUk4          @qemu @modify=Xd
+77148000 xvbitseti.w            XdXjUk5          @qemu @modify=Xd
+77150000 xvbitseti.d            XdXjUk6          @qemu @modify=Xd
+77182000 xvbitrevi.b            XdXjUk3          @qemu @modify=Xd
+77184000 xvbitrevi.h            XdXjUk4          @qemu @modify=Xd
+77188000 xvbitrevi.w            XdXjUk5          @qemu @modify=Xd
+77190000 xvbitrevi.d            XdXjUk6          @qemu @modify=Xd
+77242000 xvsat.b                XdXjUk3          @modify=Xd
+77244000 xvsat.h                XdXjUk4          @modify=Xd
+77248000 xvsat.w                XdXjUk5          @modify=Xd
+77250000 xvsat.d                XdXjUk6          @modify=Xd
+77282000 xvsat.bu               XdXjUk3          @modify=Xd
+77284000 xvsat.hu               XdXjUk4          @modify=Xd
+77288000 xvsat.wu               XdXjUk5          @modify=Xd
+77290000 xvsat.du               XdXjUk6          @modify=Xd
+772c2000 xvslli.b               XdXjUk3          @qemu @modify=Xd
+772c4000 xvslli.h               XdXjUk4          @qemu @modify=Xd
+772c8000 xvslli.w               XdXjUk5          @qemu @modify=Xd
+772d0000 xvslli.d               XdXjUk6          @qemu @modify=Xd
+77302000 xvsrli.b               XdXjUk3          @qemu @modify=Xd
+77304000 xvsrli.h               XdXjUk4          @qemu @modify=Xd
+77308000 xvsrli.w               XdXjUk5          @qemu @modify=Xd
+77310000 xvsrli.d               XdXjUk6          @qemu @modify=Xd
+77342000 xvsrai.b               XdXjUk3          @qemu @modify=Xd
+77344000 xvsrai.h               XdXjUk4          @qemu @modify=Xd
+77348000 xvsrai.w               XdXjUk5          @qemu @modify=Xd
+77350000 xvsrai.d               XdXjUk6          @qemu @modify=Xd
+77404000 xvsrlni.b.h            XdXjUk4          @modify=Xd
+77408000 xvsrlni.h.w            XdXjUk5          @modify=Xd
+77410000 xvsrlni.w.d            XdXjUk6          @modify=Xd
+77420000 xvsrlni.d.q            XdXjUk7          @modify=Xd
+77444000 xvsrlrni.b.h           XdXjUk4          @modify=Xd
+77448000 xvsrlrni.h.w           XdXjUk5          @modify=Xd
+77450000 xvsrlrni.w.d           XdXjUk6          @modify=Xd
+77460000 xvsrlrni.d.q           XdXjUk7          @modify=Xd
+77484000 xvssrlni.b.h           XdXjUk4          @modify=Xd
+77488000 xvssrlni.h.w           XdXjUk5          @modify=Xd
+77490000 xvssrlni.w.d           XdXjUk6          @modify=Xd
+774a0000 xvssrlni.d.q           XdXjUk7          @modify=Xd
+774c4000 xvssrlni.bu.h          XdXjUk4          @modify=Xd
+774c8000 xvssrlni.hu.w          XdXjUk5          @modify=Xd
+774d0000 xvssrlni.wu.d          XdXjUk6          @modify=Xd
+774e0000 xvssrlni.du.q          XdXjUk7          @modify=Xd
+77504000 xvssrlrni.b.h          XdXjUk4          @modify=Xd
+77508000 xvssrlrni.h.w          XdXjUk5          @modify=Xd
+77510000 xvssrlrni.w.d          XdXjUk6          @modify=Xd
+77520000 xvssrlrni.d.q          XdXjUk7          @modify=Xd
+77544000 xvssrlrni.bu.h         XdXjUk4          @modify=Xd
+77548000 xvssrlrni.hu.w         XdXjUk5          @modify=Xd
+77550000 xvssrlrni.wu.d         XdXjUk6          @modify=Xd
+77560000 xvssrlrni.du.q         XdXjUk7          @modify=Xd
+77584000 xvsrani.b.h            XdXjUk4          @modify=Xd
+77588000 xvsrani.h.w            XdXjUk5          @modify=Xd
+77590000 xvsrani.w.d            XdXjUk6          @modify=Xd
+775a0000 xvsrani.d.q            XdXjUk7          @modify=Xd
+775c4000 xvsrarni.b.h           XdXjUk4          @modify=Xd
+775c8000 xvsrarni.h.w           XdXjUk5          @modify=Xd
+775d0000 xvsrarni.w.d           XdXjUk6          @modify=Xd
+775e0000 xvsrarni.d.q           XdXjUk7          @modify=Xd
+77604000 xvssrani.b.h           XdXjUk4          @modify=Xd
+77608000 xvssrani.h.w           XdXjUk5          @modify=Xd
+77610000 xvssrani.w.d           XdXjUk6          @modify=Xd
+77620000 xvssrani.d.q           XdXjUk7          @modify=Xd
+77644000 xvssrani.bu.h          XdXjUk4          @modify=Xd
+77648000 xvssrani.hu.w          XdXjUk5          @modify=Xd
+77650000 xvssrani.wu.d          XdXjUk6          @modify=Xd
+77660000 xvssrani.du.q          XdXjUk7          @modify=Xd
+77684000 xvssrarni.b.h          XdXjUk4          @modify=Xd
+77688000 xvssrarni.h.w          XdXjUk5          @modify=Xd
+77690000 xvssrarni.w.d          XdXjUk6          @modify=Xd
+776a0000 xvssrarni.d.q          XdXjUk7          @modify=Xd
+776c4000 xvssrarni.bu.h         XdXjUk4          @modify=Xd
+776c8000 xvssrarni.hu.w         XdXjUk5          @modify=Xd
+776d0000 xvssrarni.wu.d         XdXjUk6          @modify=Xd
+776e0000 xvssrarni.du.q         XdXjUk7          @modify=Xd
+77800000 xvextrins.d            XdXjUk8          @modify=Xd
+77840000 xvextrins.w            XdXjUk8          @modify=Xd
+77880000 xvextrins.h            XdXjUk8          @modify=Xd
+778c0000 xvextrins.b            XdXjUk8          @modify=Xd
+77900000 xvshuf4i.b             XdXjUk8          @modify=Xd
+77940000 xvshuf4i.h             XdXjUk8          @modify=Xd
+77980000 xvshuf4i.w             XdXjUk8          @modify=Xd
+779c0000 xvshuf4i.d             XdXjUk8          @modify=Xd
+77c40000 xvbitseli.b            XdXjUk8          @qemu @modify=Xd
+77d00000 xvandi.b               XdXjUk8          @qemu @modify=Xd
+77d40000 xvori.b                XdXjUk8          @qemu @modify=Xd
+77d80000 xvxori.b               XdXjUk8          @qemu @modify=Xd
+77dc0000 xvnori.b               XdXjUk8          @qemu @modify=Xd
+77e00000 xvldi                  XdSj13           @qemu @modify=Xd
+77e40000 xvpermi.w              XdXjUk8          @modify=Xd
+77e80000 xvpermi.d              XdXjUk8          @modify=Xd
+77ec0000 xvpermi.q              XdXjUk8          @modify=Xd

--- a/lbt.txt
+++ b/lbt.txt
@@ -1,173 +1,173 @@
-00000800 movgr2scr              TdJ             @lbt @qemu
-00000c00 movscr2gr              DTj             @lbt @qemu
+00000800 movgr2scr              TdJ             @lbt @qemu @modify=Td
+00000c00 movscr2gr              DTj             @lbt @qemu @modify=D
 00007000 x86mttop               Uj3             @lbt
-00007400 x86mftop               D               @lbt
-00007800 x86setloope            DJ              @lbt @orig_name=setx86loope
-00007c00 x86setloopne           DJ              @lbt @orig_name=setx86loopne
-00008000 x86inc.b               J               @lbt
-00008001 x86inc.h               J               @lbt
-00008002 x86inc.w               J               @lbt
-00008003 x86inc.d               J               @lbt
-00008004 x86dec.b               J               @lbt
-00008005 x86dec.h               J               @lbt
-00008006 x86dec.w               J               @lbt
-00008007 x86dec.d               J               @lbt
+00007400 x86mftop               D               @lbt @modify=D
+00007800 x86setloope            DJ              @lbt @orig_name=setx86loope @modify=D
+00007c00 x86setloopne           DJ              @lbt @orig_name=setx86loopne @modify=D
+00008000 x86inc.b               J               @lbt @modify=J
+00008001 x86inc.h               J               @lbt @modify=J
+00008002 x86inc.w               J               @lbt @modify=J
+00008003 x86inc.d               J               @lbt @modify=J
+00008004 x86dec.b               J               @lbt @modify=J
+00008005 x86dec.h               J               @lbt @modify=J
+00008006 x86dec.w               J               @lbt @modify=J
+00008007 x86dec.d               J               @lbt @modify=J
 00008008 x86settm               EMPTY           @lbt
 00008009 x86inctop              EMPTY           @lbt
 00008028 x86clrtm               EMPTY           @lbt
 00008029 x86dectop              EMPTY           @lbt
-001a0000 rotr.b                 DJK             @lbt @qemu
-001a8000 rotr.h                 DJK             @lbt @qemu
-00290000 addu12i.w              DJSk5           @lbt
-00298000 addu12i.d              DJSk5           @lbt
-00300000 adc.b                  DJK             @lbt
-00308000 adc.h                  DJK             @lbt
-00310000 adc.w                  DJK             @lbt
-00318000 adc.d                  DJK             @lbt
-00320000 sbc.b                  DJK             @lbt
-00328000 sbc.h                  DJK             @lbt
-00330000 sbc.w                  DJK             @lbt
-00338000 sbc.d                  DJK             @lbt
-00340000 rcr.b                  DJK             @lbt
-00348000 rcr.h                  DJK             @lbt
-00350000 rcr.w                  DJK             @lbt
-00358000 rcr.d                  DJK             @lbt
-00364000 armmove                DJUk4           @lbt
-00368000 x86setj                DUk4            @lbt @orig_name=setx86j
-0036c000 armsetj                DUk4            @lbt @orig_name=setarmj
-00370010 armadd.w               JKUd4           @lbt
-00378010 armsub.w               JKUd4           @lbt
-00380010 armadc.w               JKUd4           @lbt
-00388010 armsbc.w               JKUd4           @lbt
-00390010 armand.w               JKUd4           @lbt
-00398010 armor.w                JKUd4           @lbt
-003a0010 armxor.w               JKUd4           @lbt
-003a8010 armsll.w               JKUd4           @lbt
-003b0010 armsrl.w               JKUd4           @lbt
-003b8010 armsra.w               JKUd4           @lbt
-003c0010 armrotr.w              JKUd4           @lbt
-003c8010 armslli.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4
-003d0010 armsrli.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4
-003d8010 armsrai.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4
-003e0010 armrotri.w             JUd4Uk5         @lbt @orig_fmt=JUk5Ud4
-003e8000 x86mul.b               JK              @lbt
-003e8001 x86mul.h               JK              @lbt
-003e8002 x86mul.w               JK              @lbt
-003e8003 x86mul.d               JK              @lbt
-003e8004 x86mul.bu              JK              @lbt
-003e8005 x86mul.hu              JK              @lbt
-003e8006 x86mul.wu              JK              @lbt
-003e8007 x86mul.du              JK              @lbt
-003f0000 x86add.wu              JK              @lbt
-003f0001 x86add.du              JK              @lbt
-003f0002 x86sub.wu              JK              @lbt
-003f0003 x86sub.du              JK              @lbt
-003f0004 x86add.b               JK              @lbt
-003f0005 x86add.h               JK              @lbt
-003f0006 x86add.w               JK              @lbt
-003f0007 x86add.d               JK              @lbt
-003f0008 x86sub.b               JK              @lbt
-003f0009 x86sub.h               JK              @lbt
-003f000a x86sub.w               JK              @lbt
-003f000b x86sub.d               JK              @lbt
-003f000c x86adc.b               JK              @lbt
-003f000d x86adc.h               JK              @lbt
-003f000e x86adc.w               JK              @lbt
-003f000f x86adc.d               JK              @lbt
-003f0010 x86sbc.b               JK              @lbt
-003f0011 x86sbc.h               JK              @lbt
-003f0012 x86sbc.w               JK              @lbt
-003f0013 x86sbc.d               JK              @lbt
-003f0014 x86sll.b               JK              @lbt
-003f0015 x86sll.h               JK              @lbt
-003f0016 x86sll.w               JK              @lbt
-003f0017 x86sll.d               JK              @lbt
-003f0018 x86srl.b               JK              @lbt
-003f0019 x86srl.h               JK              @lbt
-003f001a x86srl.w               JK              @lbt
-003f001b x86srl.d               JK              @lbt
-003f001c x86sra.b               JK              @lbt
-003f001d x86sra.h               JK              @lbt
-003f001e x86sra.w               JK              @lbt
-003f001f x86sra.d               JK              @lbt
-003f8000 x86rotr.b              JK              @lbt
-003f8001 x86rotr.h              JK              @lbt
-003f8002 x86rotr.d              JK              @lbt
-003f8003 x86rotr.w              JK              @lbt
-003f8004 x86rotl.b              JK              @lbt
-003f8005 x86rotl.h              JK              @lbt
-003f8006 x86rotl.w              JK              @lbt
-003f8007 x86rotl.d              JK              @lbt
-003f8008 x86rcr.b               JK              @lbt
-003f8009 x86rcr.h               JK              @lbt
-003f800a x86rcr.w               JK              @lbt
-003f800b x86rcr.d               JK              @lbt
-003f800c x86rcl.b               JK              @lbt
-003f800d x86rcl.h               JK              @lbt
-003f800e x86rcl.w               JK              @lbt
-003f800f x86rcl.d               JK              @lbt
-003f8010 x86and.b               JK              @lbt
-003f8011 x86and.h               JK              @lbt
-003f8012 x86and.w               JK              @lbt
-003f8013 x86and.d               JK              @lbt
-003f8014 x86or.b                JK              @lbt
-003f8015 x86or.h                JK              @lbt
-003f8016 x86or.w                JK              @lbt
-003f8017 x86or.d                JK              @lbt
-003f8018 x86xor.b               JK              @lbt
-003f8019 x86xor.h               JK              @lbt
-003f801a x86xor.w               JK              @lbt
-003f801b x86xor.d               JK              @lbt
-003fc01c armnot.w               JUk4            @lbt
-003fc01d armmov.w               JUk4            @lbt
-003fc01e armmov.d               JUk4            @lbt
-003fc01f armrrx.w               JUk4            @lbt
-004c2000 rotri.b                DJUk3           @lbt @qemu
-004c4000 rotri.h                DJUk4           @lbt @qemu
-00502000 rcri.b                 DJUk3           @lbt
-00504000 rcri.h                 DJUk4           @lbt
-00508000 rcri.w                 DJUk5           @lbt
-00510000 rcri.d                 DJUk6           @lbt
-00542000 x86slli.b              JUk3            @lbt
-00542004 x86srli.b              JUk3            @lbt
-00542008 x86srai.b              JUk3            @lbt
-0054200c x86rotri.b             JUk3            @lbt
-00542010 x86rcri.b              JUk3            @lbt
-00542014 x86rotli.b             JUk3            @lbt
-00542018 x86rcli.b              JUk3            @lbt
-00544001 x86slli.h              JUk4            @lbt
-00544005 x86srli.h              JUk4            @lbt
-00544009 x86srai.h              JUk4            @lbt
-0054400d x86rotri.h             JUk4            @lbt
-00544011 x86rcri.h              JUk4            @lbt
-00544015 x86rotli.h             JUk4            @lbt
-00544019 x86rcli.h              JUk4            @lbt
-00548002 x86slli.w              JUk5            @lbt
-00548006 x86srli.w              JUk5            @lbt
-0054800a x86srai.w              JUk5            @lbt
-0054800e x86rotri.w             JUk5            @lbt
-00548012 x86rcri.w              JUk5            @lbt
-00548016 x86rotli.w             JUk5            @lbt
-0054801a x86rcli.w              JUk5            @lbt
-00550003 x86slli.d              JUk6            @lbt
-00550007 x86srli.d              JUk6            @lbt
-0055000b x86srai.d              JUk6            @lbt
-0055000f x86rotri.d             JUk6            @lbt
-00550013 x86rcri.d              JUk6            @lbt
-00550017 x86rotli.d             JUk6            @lbt
-0055001b x86rcli.d              JUk6            @lbt
-00580000 x86settag              DUj5Uk8         @lbt
-005c0000 x86mfflag              DUk8            @lbt
-005c0020 x86mtflag              DUk8            @lbt
-005c0040 armmfflag              DUk8            @lbt
-005c0060 armmtflag              DUk8            @lbt
-0114e000 fcvt.ld.d              FdFj            @lbt
-0114e400 fcvt.ud.d              FdFj            @lbt
-01150000 fcvt.d.ld              FdFjFk          @lbt
-2e000000 ldl.w                  DJSk12          @lbt
-2e400000 ldr.w                  DJSk12          @lbt
-2e800000 ldl.d                  DJSk12          @lbt
-2ec00000 ldr.d                  DJSk12          @lbt
+001a0000 rotr.b                 DJK             @lbt @qemu @modify=D
+001a8000 rotr.h                 DJK             @lbt @qemu @modify=D
+00290000 addu12i.w              DJSk5           @lbt @modify=D
+00298000 addu12i.d              DJSk5           @lbt @modify=D
+00300000 adc.b                  DJK             @lbt @modify=D
+00308000 adc.h                  DJK             @lbt @modify=D
+00310000 adc.w                  DJK             @lbt @modify=D
+00318000 adc.d                  DJK             @lbt @modify=D
+00320000 sbc.b                  DJK             @lbt @modify=D
+00328000 sbc.h                  DJK             @lbt @modify=D
+00330000 sbc.w                  DJK             @lbt @modify=D
+00338000 sbc.d                  DJK             @lbt @modify=D
+00340000 rcr.b                  DJK             @lbt @modify=D
+00348000 rcr.h                  DJK             @lbt @modify=D
+00350000 rcr.w                  DJK             @lbt @modify=D
+00358000 rcr.d                  DJK             @lbt @modify=D
+00364000 armmove                DJUk4           @lbt @modify=D
+00368000 x86setj                DUk4            @lbt @orig_name=setx86j @modify=D
+0036c000 armsetj                DUk4            @lbt @orig_name=setarmj @modify=D
+00370010 armadd.w               JKUd4           @lbt @modify=J
+00378010 armsub.w               JKUd4           @lbt @modify=J
+00380010 armadc.w               JKUd4           @lbt @modify=J
+00388010 armsbc.w               JKUd4           @lbt @modify=J
+00390010 armand.w               JKUd4           @lbt @modify=J
+00398010 armor.w                JKUd4           @lbt @modify=J
+003a0010 armxor.w               JKUd4           @lbt @modify=J
+003a8010 armsll.w               JKUd4           @lbt @modify=J
+003b0010 armsrl.w               JKUd4           @lbt @modify=J
+003b8010 armsra.w               JKUd4           @lbt @modify=J
+003c0010 armrotr.w              JKUd4           @lbt @modify=J
+003c8010 armslli.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4 @modify=J
+003d0010 armsrli.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4 @modify=J
+003d8010 armsrai.w              JUd4Uk5         @lbt @orig_fmt=JUk5Ud4 @modify=J
+003e0010 armrotri.w             JUd4Uk5         @lbt @orig_fmt=JUk5Ud4 @modify=J
+003e8000 x86mul.b               JK              @lbt @modify=J
+003e8001 x86mul.h               JK              @lbt @modify=J
+003e8002 x86mul.w               JK              @lbt @modify=J
+003e8003 x86mul.d               JK              @lbt @modify=J
+003e8004 x86mul.bu              JK              @lbt @modify=J
+003e8005 x86mul.hu              JK              @lbt @modify=J
+003e8006 x86mul.wu              JK              @lbt @modify=J
+003e8007 x86mul.du              JK              @lbt @modify=J
+003f0000 x86add.wu              JK              @lbt @modify=J
+003f0001 x86add.du              JK              @lbt @modify=J
+003f0002 x86sub.wu              JK              @lbt @modify=J
+003f0003 x86sub.du              JK              @lbt @modify=J
+003f0004 x86add.b               JK              @lbt @modify=J
+003f0005 x86add.h               JK              @lbt @modify=J
+003f0006 x86add.w               JK              @lbt @modify=J
+003f0007 x86add.d               JK              @lbt @modify=J
+003f0008 x86sub.b               JK              @lbt @modify=J
+003f0009 x86sub.h               JK              @lbt @modify=J
+003f000a x86sub.w               JK              @lbt @modify=J
+003f000b x86sub.d               JK              @lbt @modify=J
+003f000c x86adc.b               JK              @lbt @modify=J
+003f000d x86adc.h               JK              @lbt @modify=J
+003f000e x86adc.w               JK              @lbt @modify=J
+003f000f x86adc.d               JK              @lbt @modify=J
+003f0010 x86sbc.b               JK              @lbt @modify=J
+003f0011 x86sbc.h               JK              @lbt @modify=J
+003f0012 x86sbc.w               JK              @lbt @modify=J
+003f0013 x86sbc.d               JK              @lbt @modify=J
+003f0014 x86sll.b               JK              @lbt @modify=J
+003f0015 x86sll.h               JK              @lbt @modify=J
+003f0016 x86sll.w               JK              @lbt @modify=J
+003f0017 x86sll.d               JK              @lbt @modify=J
+003f0018 x86srl.b               JK              @lbt @modify=J
+003f0019 x86srl.h               JK              @lbt @modify=J
+003f001a x86srl.w               JK              @lbt @modify=J
+003f001b x86srl.d               JK              @lbt @modify=J
+003f001c x86sra.b               JK              @lbt @modify=J
+003f001d x86sra.h               JK              @lbt @modify=J
+003f001e x86sra.w               JK              @lbt @modify=J
+003f001f x86sra.d               JK              @lbt @modify=J
+003f8000 x86rotr.b              JK              @lbt @modify=J
+003f8001 x86rotr.h              JK              @lbt @modify=J
+003f8002 x86rotr.d              JK              @lbt @modify=J
+003f8003 x86rotr.w              JK              @lbt @modify=J
+003f8004 x86rotl.b              JK              @lbt @modify=J
+003f8005 x86rotl.h              JK              @lbt @modify=J
+003f8006 x86rotl.w              JK              @lbt @modify=J
+003f8007 x86rotl.d              JK              @lbt @modify=J
+003f8008 x86rcr.b               JK              @lbt @modify=J
+003f8009 x86rcr.h               JK              @lbt @modify=J
+003f800a x86rcr.w               JK              @lbt @modify=J
+003f800b x86rcr.d               JK              @lbt @modify=J
+003f800c x86rcl.b               JK              @lbt @modify=J
+003f800d x86rcl.h               JK              @lbt @modify=J
+003f800e x86rcl.w               JK              @lbt @modify=J
+003f800f x86rcl.d               JK              @lbt @modify=J
+003f8010 x86and.b               JK              @lbt @modify=J
+003f8011 x86and.h               JK              @lbt @modify=J
+003f8012 x86and.w               JK              @lbt @modify=J
+003f8013 x86and.d               JK              @lbt @modify=J
+003f8014 x86or.b                JK              @lbt @modify=J
+003f8015 x86or.h                JK              @lbt @modify=J
+003f8016 x86or.w                JK              @lbt @modify=J
+003f8017 x86or.d                JK              @lbt @modify=J
+003f8018 x86xor.b               JK              @lbt @modify=J
+003f8019 x86xor.h               JK              @lbt @modify=J
+003f801a x86xor.w               JK              @lbt @modify=J
+003f801b x86xor.d               JK              @lbt @modify=J
+003fc01c armnot.w               JUk4            @lbt @modify=J
+003fc01d armmov.w               JUk4            @lbt @modify=J
+003fc01e armmov.d               JUk4            @lbt @modify=J
+003fc01f armrrx.w               JUk4            @lbt @modify=J
+004c2000 rotri.b                DJUk3           @lbt @qemu @modify=D
+004c4000 rotri.h                DJUk4           @lbt @qemu @modify=D
+00502000 rcri.b                 DJUk3           @lbt @modify=D
+00504000 rcri.h                 DJUk4           @lbt @modify=D
+00508000 rcri.w                 DJUk5           @lbt @modify=D
+00510000 rcri.d                 DJUk6           @lbt @modify=D
+00542000 x86slli.b              JUk3            @lbt @modify=J
+00542004 x86srli.b              JUk3            @lbt @modify=J
+00542008 x86srai.b              JUk3            @lbt @modify=J
+0054200c x86rotri.b             JUk3            @lbt @modify=J
+00542010 x86rcri.b              JUk3            @lbt @modify=J
+00542014 x86rotli.b             JUk3            @lbt @modify=J
+00542018 x86rcli.b              JUk3            @lbt @modify=J
+00544001 x86slli.h              JUk4            @lbt @modify=J
+00544005 x86srli.h              JUk4            @lbt @modify=J
+00544009 x86srai.h              JUk4            @lbt @modify=J
+0054400d x86rotri.h             JUk4            @lbt @modify=J
+00544011 x86rcri.h              JUk4            @lbt @modify=J
+00544015 x86rotli.h             JUk4            @lbt @modify=J
+00544019 x86rcli.h              JUk4            @lbt @modify=J
+00548002 x86slli.w              JUk5            @lbt @modify=J
+00548006 x86srli.w              JUk5            @lbt @modify=J
+0054800a x86srai.w              JUk5            @lbt @modify=J
+0054800e x86rotri.w             JUk5            @lbt @modify=J
+00548012 x86rcri.w              JUk5            @lbt @modify=J
+00548016 x86rotli.w             JUk5            @lbt @modify=J
+0054801a x86rcli.w              JUk5            @lbt @modify=J
+00550003 x86slli.d              JUk6            @lbt @modify=J
+00550007 x86srli.d              JUk6            @lbt @modify=J
+0055000b x86srai.d              JUk6            @lbt @modify=J
+0055000f x86rotri.d             JUk6            @lbt @modify=J
+00550013 x86rcri.d              JUk6            @lbt @modify=J
+00550017 x86rotli.d             JUk6            @lbt @modify=J
+0055001b x86rcli.d              JUk6            @lbt @modify=J
+00580000 x86settag              DUj5Uk8         @lbt @modify=D
+005c0000 x86mfflag              DUk8            @lbt @modify=D
+005c0020 x86mtflag              DUk8            @lbt @modify=D
+005c0040 armmfflag              DUk8            @lbt @modify=D
+005c0060 armmtflag              DUk8            @lbt @modify=D
+0114e000 fcvt.ld.d              FdFj            @lbt @modify=Fd
+0114e400 fcvt.ud.d              FdFj            @lbt @modify=Fd
+01150000 fcvt.d.ld              FdFjFk          @lbt @modify=Fd
+2e000000 ldl.w                  DJSk12          @lbt @modify=D
+2e400000 ldr.w                  DJSk12          @lbt @modify=D
+2e800000 ldl.d                  DJSk12          @lbt @modify=D
+2ec00000 ldr.d                  DJSk12          @lbt @modify=D
 2f000000 stl.w                  DJSk12          @lbt
 2f400000 str.w                  DJSk12          @lbt
 2f800000 stl.d                  DJSk12          @lbt

--- a/lsx.txt
+++ b/lsx.txt
@@ -1,717 +1,717 @@
-09100000 vfmadd.s               VdVjVkVa
-09200000 vfmadd.d               VdVjVkVa
-09500000 vfmsub.s               VdVjVkVa
-09600000 vfmsub.d               VdVjVkVa
-09900000 vfnmadd.s              VdVjVkVa
-09a00000 vfnmadd.d              VdVjVkVa
-09d00000 vfnmsub.s              VdVjVkVa
-09e00000 vfnmsub.d              VdVjVkVa
-0c500000 vfcmp.caf.s            VdVjVk
-0c508000 vfcmp.saf.s            VdVjVk
-0c510000 vfcmp.clt.s            VdVjVk
-0c518000 vfcmp.slt.s            VdVjVk
-0c520000 vfcmp.ceq.s            VdVjVk
-0c528000 vfcmp.seq.s            VdVjVk
-0c530000 vfcmp.cle.s            VdVjVk
-0c538000 vfcmp.sle.s            VdVjVk
-0c540000 vfcmp.cun.s            VdVjVk
-0c548000 vfcmp.sun.s            VdVjVk
-0c550000 vfcmp.cult.s           VdVjVk
-0c558000 vfcmp.sult.s           VdVjVk
-0c560000 vfcmp.cueq.s           VdVjVk
-0c568000 vfcmp.sueq.s           VdVjVk
-0c570000 vfcmp.cule.s           VdVjVk
-0c578000 vfcmp.sule.s           VdVjVk
-0c580000 vfcmp.cne.s            VdVjVk
-0c588000 vfcmp.sne.s            VdVjVk
-0c5a0000 vfcmp.cor.s            VdVjVk
-0c5a8000 vfcmp.sor.s            VdVjVk
-0c5c0000 vfcmp.cune.s           VdVjVk
-0c5c8000 vfcmp.sune.s           VdVjVk
-0c600000 vfcmp.caf.d            VdVjVk
-0c608000 vfcmp.saf.d            VdVjVk
-0c610000 vfcmp.clt.d            VdVjVk
-0c618000 vfcmp.slt.d            VdVjVk
-0c620000 vfcmp.ceq.d            VdVjVk
-0c628000 vfcmp.seq.d            VdVjVk
-0c630000 vfcmp.cle.d            VdVjVk
-0c638000 vfcmp.sle.d            VdVjVk
-0c640000 vfcmp.cun.d            VdVjVk
-0c648000 vfcmp.sun.d            VdVjVk
-0c650000 vfcmp.cult.d           VdVjVk
-0c658000 vfcmp.sult.d           VdVjVk
-0c660000 vfcmp.cueq.d           VdVjVk
-0c668000 vfcmp.sueq.d           VdVjVk
-0c670000 vfcmp.cule.d           VdVjVk
-0c678000 vfcmp.sule.d           VdVjVk
-0c680000 vfcmp.cne.d            VdVjVk
-0c688000 vfcmp.sne.d            VdVjVk
-0c6a0000 vfcmp.cor.d            VdVjVk
-0c6a8000 vfcmp.sor.d            VdVjVk
-0c6c0000 vfcmp.cune.d           VdVjVk
-0c6c8000 vfcmp.sune.d           VdVjVk
-0d100000 vbitsel.v              VdVjVkVa        @qemu
-0d500000 vshuf.b                VdVjVkVa        @qemu
-2c000000 vld                    VdJSk12         @qemu
+09100000 vfmadd.s               VdVjVkVa        @modify=Vd
+09200000 vfmadd.d               VdVjVkVa        @modify=Vd
+09500000 vfmsub.s               VdVjVkVa        @modify=Vd
+09600000 vfmsub.d               VdVjVkVa        @modify=Vd
+09900000 vfnmadd.s              VdVjVkVa        @modify=Vd
+09a00000 vfnmadd.d              VdVjVkVa        @modify=Vd
+09d00000 vfnmsub.s              VdVjVkVa        @modify=Vd
+09e00000 vfnmsub.d              VdVjVkVa        @modify=Vd
+0c500000 vfcmp.caf.s            VdVjVk          @modify=Vd
+0c508000 vfcmp.saf.s            VdVjVk          @modify=Vd
+0c510000 vfcmp.clt.s            VdVjVk          @modify=Vd
+0c518000 vfcmp.slt.s            VdVjVk          @modify=Vd
+0c520000 vfcmp.ceq.s            VdVjVk          @modify=Vd
+0c528000 vfcmp.seq.s            VdVjVk          @modify=Vd
+0c530000 vfcmp.cle.s            VdVjVk          @modify=Vd
+0c538000 vfcmp.sle.s            VdVjVk          @modify=Vd
+0c540000 vfcmp.cun.s            VdVjVk          @modify=Vd
+0c548000 vfcmp.sun.s            VdVjVk          @modify=Vd
+0c550000 vfcmp.cult.s           VdVjVk          @modify=Vd
+0c558000 vfcmp.sult.s           VdVjVk          @modify=Vd
+0c560000 vfcmp.cueq.s           VdVjVk          @modify=Vd
+0c568000 vfcmp.sueq.s           VdVjVk          @modify=Vd
+0c570000 vfcmp.cule.s           VdVjVk          @modify=Vd
+0c578000 vfcmp.sule.s           VdVjVk          @modify=Vd
+0c580000 vfcmp.cne.s            VdVjVk          @modify=Vd
+0c588000 vfcmp.sne.s            VdVjVk          @modify=Vd
+0c5a0000 vfcmp.cor.s            VdVjVk          @modify=Vd
+0c5a8000 vfcmp.sor.s            VdVjVk          @modify=Vd
+0c5c0000 vfcmp.cune.s           VdVjVk          @modify=Vd
+0c5c8000 vfcmp.sune.s           VdVjVk          @modify=Vd
+0c600000 vfcmp.caf.d            VdVjVk          @modify=Vd
+0c608000 vfcmp.saf.d            VdVjVk          @modify=Vd
+0c610000 vfcmp.clt.d            VdVjVk          @modify=Vd
+0c618000 vfcmp.slt.d            VdVjVk          @modify=Vd
+0c620000 vfcmp.ceq.d            VdVjVk          @modify=Vd
+0c628000 vfcmp.seq.d            VdVjVk          @modify=Vd
+0c630000 vfcmp.cle.d            VdVjVk          @modify=Vd
+0c638000 vfcmp.sle.d            VdVjVk          @modify=Vd
+0c640000 vfcmp.cun.d            VdVjVk          @modify=Vd
+0c648000 vfcmp.sun.d            VdVjVk          @modify=Vd
+0c650000 vfcmp.cult.d           VdVjVk          @modify=Vd
+0c658000 vfcmp.sult.d           VdVjVk          @modify=Vd
+0c660000 vfcmp.cueq.d           VdVjVk          @modify=Vd
+0c668000 vfcmp.sueq.d           VdVjVk          @modify=Vd
+0c670000 vfcmp.cule.d           VdVjVk          @modify=Vd
+0c678000 vfcmp.sule.d           VdVjVk          @modify=Vd
+0c680000 vfcmp.cne.d            VdVjVk          @modify=Vd
+0c688000 vfcmp.sne.d            VdVjVk          @modify=Vd
+0c6a0000 vfcmp.cor.d            VdVjVk          @modify=Vd
+0c6a8000 vfcmp.sor.d            VdVjVk          @modify=Vd
+0c6c0000 vfcmp.cune.d           VdVjVk          @modify=Vd
+0c6c8000 vfcmp.sune.d           VdVjVk          @modify=Vd
+0d100000 vbitsel.v              VdVjVkVa        @qemu @modify=Vd
+0d500000 vshuf.b                VdVjVkVa        @qemu @modify=Vd
+2c000000 vld                    VdJSk12         @qemu @modify=Vd
 2c400000 vst                    VdJSk12         @qemu
-30100000 vldrepl.d              VdJSk9          @orig_fmt=VdJSk9ps3 @qemu
-30200000 vldrepl.w              VdJSk10         @orig_fmt=VdJSk10ps2 @qemu
-30400000 vldrepl.h              VdJSk11         @orig_fmt=VdJSk11ps1 @qemu
-30800000 vldrepl.b              VdJSk12         @qemu
+30100000 vldrepl.d              VdJSk9          @orig_fmt=VdJSk9ps3 @qemu @modify=Vd
+30200000 vldrepl.w              VdJSk10         @orig_fmt=VdJSk10ps2 @qemu @modify=Vd
+30400000 vldrepl.h              VdJSk11         @orig_fmt=VdJSk11ps1 @qemu @modify=Vd
+30800000 vldrepl.b              VdJSk12         @qemu @modify=Vd
 31100000 vstelm.d               VdJSk8Un1       @orig_fmt=VdJSk8ps3Un1 @qemu
 31200000 vstelm.w               VdJSk8Un2       @orig_fmt=VdJSk8ps2Un2 @qemu
 31400000 vstelm.h               VdJSk8Un3       @orig_fmt=VdJSk8ps1Un3 @qemu
 31800000 vstelm.b               VdJSk8Un4       @qemu
-38400000 vldx                   VdJK            @qemu
+38400000 vldx                   VdJK            @qemu @modify=Vd
 38440000 vstx                   VdJK            @qemu
-70000000 vseq.b                 VdVjVk          @qemu
-70008000 vseq.h                 VdVjVk          @qemu
-70010000 vseq.w                 VdVjVk          @qemu
-70018000 vseq.d                 VdVjVk          @qemu
-70020000 vsle.b                 VdVjVk          @qemu
-70028000 vsle.h                 VdVjVk          @qemu
-70030000 vsle.w                 VdVjVk          @qemu
-70038000 vsle.d                 VdVjVk          @qemu
-70040000 vsle.bu                VdVjVk          @qemu
-70048000 vsle.hu                VdVjVk          @qemu
-70050000 vsle.wu                VdVjVk          @qemu
-70058000 vsle.du                VdVjVk          @qemu
-70060000 vslt.b                 VdVjVk          @qemu
-70068000 vslt.h                 VdVjVk          @qemu
-70070000 vslt.w                 VdVjVk          @qemu
-70078000 vslt.d                 VdVjVk          @qemu
-70080000 vslt.bu                VdVjVk          @qemu
-70088000 vslt.hu                VdVjVk          @qemu
-70090000 vslt.wu                VdVjVk          @qemu
-70098000 vslt.du                VdVjVk          @qemu
-700a0000 vadd.b                 VdVjVk          @qemu
-700a8000 vadd.h                 VdVjVk          @qemu
-700b0000 vadd.w                 VdVjVk          @qemu
-700b8000 vadd.d                 VdVjVk          @qemu
-700c0000 vsub.b                 VdVjVk          @qemu
-700c8000 vsub.h                 VdVjVk          @qemu
-700d0000 vsub.w                 VdVjVk          @qemu
-700d8000 vsub.d                 VdVjVk          @qemu
-701e0000 vaddwev.h.b            VdVjVk
-701e8000 vaddwev.w.h            VdVjVk
-701f0000 vaddwev.d.w            VdVjVk
-701f8000 vaddwev.q.d            VdVjVk
-70200000 vsubwev.h.b            VdVjVk
-70208000 vsubwev.w.h            VdVjVk
-70210000 vsubwev.d.w            VdVjVk
-70218000 vsubwev.q.d            VdVjVk
-70220000 vaddwod.h.b            VdVjVk
-70228000 vaddwod.w.h            VdVjVk
-70230000 vaddwod.d.w            VdVjVk
-70238000 vaddwod.q.d            VdVjVk
-70240000 vsubwod.h.b            VdVjVk
-70248000 vsubwod.w.h            VdVjVk
-70250000 vsubwod.d.w            VdVjVk
-70258000 vsubwod.q.d            VdVjVk
-702e0000 vaddwev.h.bu           VdVjVk
-702e8000 vaddwev.w.hu           VdVjVk
-702f0000 vaddwev.d.wu           VdVjVk
-702f8000 vaddwev.q.du           VdVjVk
-70300000 vsubwev.h.bu           VdVjVk
-70308000 vsubwev.w.hu           VdVjVk
-70310000 vsubwev.d.wu           VdVjVk
-70318000 vsubwev.q.du           VdVjVk
-70320000 vaddwod.h.bu           VdVjVk
-70328000 vaddwod.w.hu           VdVjVk
-70330000 vaddwod.d.wu           VdVjVk
-70338000 vaddwod.q.du           VdVjVk
-70340000 vsubwod.h.bu           VdVjVk
-70348000 vsubwod.w.hu           VdVjVk
-70350000 vsubwod.d.wu           VdVjVk
-70358000 vsubwod.q.du           VdVjVk
-703e0000 vaddwev.h.bu.b         VdVjVk
-703e8000 vaddwev.w.hu.h         VdVjVk
-703f0000 vaddwev.d.wu.w         VdVjVk
-703f8000 vaddwev.q.du.d         VdVjVk
-70400000 vaddwod.h.bu.b         VdVjVk
-70408000 vaddwod.w.hu.h         VdVjVk
-70410000 vaddwod.d.wu.w         VdVjVk
-70418000 vaddwod.q.du.d         VdVjVk
-70460000 vsadd.b                VdVjVk          @qemu
-70468000 vsadd.h                VdVjVk          @qemu
-70470000 vsadd.w                VdVjVk          @qemu
-70478000 vsadd.d                VdVjVk          @qemu
-70480000 vssub.b                VdVjVk          @qemu
-70488000 vssub.h                VdVjVk          @qemu
-70490000 vssub.w                VdVjVk          @qemu
-70498000 vssub.d                VdVjVk          @qemu
-704a0000 vsadd.bu               VdVjVk          @qemu
-704a8000 vsadd.hu               VdVjVk          @qemu
-704b0000 vsadd.wu               VdVjVk          @qemu
-704b8000 vsadd.du               VdVjVk          @qemu
-704c0000 vssub.bu               VdVjVk          @qemu
-704c8000 vssub.hu               VdVjVk          @qemu
-704d0000 vssub.wu               VdVjVk          @qemu
-704d8000 vssub.du               VdVjVk          @qemu
-70540000 vhaddw.h.b             VdVjVk
-70548000 vhaddw.w.h             VdVjVk
-70550000 vhaddw.d.w             VdVjVk
-70558000 vhaddw.q.d             VdVjVk
-70560000 vhsubw.h.b             VdVjVk
-70568000 vhsubw.w.h             VdVjVk
-70570000 vhsubw.d.w             VdVjVk
-70578000 vhsubw.q.d             VdVjVk
-70580000 vhaddw.hu.bu           VdVjVk
-70588000 vhaddw.wu.hu           VdVjVk
-70590000 vhaddw.du.wu           VdVjVk
-70598000 vhaddw.qu.du           VdVjVk
-705a0000 vhsubw.hu.bu           VdVjVk
-705a8000 vhsubw.wu.hu           VdVjVk
-705b0000 vhsubw.du.wu           VdVjVk
-705b8000 vhsubw.qu.du           VdVjVk
-705c0000 vadda.b                VdVjVk
-705c8000 vadda.h                VdVjVk
-705d0000 vadda.w                VdVjVk
-705d8000 vadda.d                VdVjVk
-70600000 vabsd.b                VdVjVk
-70608000 vabsd.h                VdVjVk
-70610000 vabsd.w                VdVjVk
-70618000 vabsd.d                VdVjVk
-70620000 vabsd.bu               VdVjVk
-70628000 vabsd.hu               VdVjVk
-70630000 vabsd.wu               VdVjVk
-70638000 vabsd.du               VdVjVk
-70640000 vavg.b                 VdVjVk
-70648000 vavg.h                 VdVjVk
-70650000 vavg.w                 VdVjVk
-70658000 vavg.d                 VdVjVk
-70660000 vavg.bu                VdVjVk
-70668000 vavg.hu                VdVjVk
-70670000 vavg.wu                VdVjVk
-70678000 vavg.du                VdVjVk
-70680000 vavgr.b                VdVjVk
-70688000 vavgr.h                VdVjVk
-70690000 vavgr.w                VdVjVk
-70698000 vavgr.d                VdVjVk
-706a0000 vavgr.bu               VdVjVk
-706a8000 vavgr.hu               VdVjVk
-706b0000 vavgr.wu               VdVjVk
-706b8000 vavgr.du               VdVjVk
-70700000 vmax.b                 VdVjVk          @qemu
-70708000 vmax.h                 VdVjVk          @qemu
-70710000 vmax.w                 VdVjVk          @qemu
-70718000 vmax.d                 VdVjVk          @qemu
-70720000 vmin.b                 VdVjVk          @qemu
-70728000 vmin.h                 VdVjVk          @qemu
-70730000 vmin.w                 VdVjVk          @qemu
-70738000 vmin.d                 VdVjVk          @qemu
-70740000 vmax.bu                VdVjVk          @qemu
-70748000 vmax.hu                VdVjVk          @qemu
-70750000 vmax.wu                VdVjVk          @qemu
-70758000 vmax.du                VdVjVk          @qemu
-70760000 vmin.bu                VdVjVk          @qemu
-70768000 vmin.hu                VdVjVk          @qemu
-70770000 vmin.wu                VdVjVk          @qemu
-70778000 vmin.du                VdVjVk          @qemu
-70840000 vmul.b                 VdVjVk          @qemu
-70848000 vmul.h                 VdVjVk          @qemu
-70850000 vmul.w                 VdVjVk          @qemu
-70858000 vmul.d                 VdVjVk          @qemu
-70860000 vmuh.b                 VdVjVk
-70868000 vmuh.h                 VdVjVk
-70870000 vmuh.w                 VdVjVk
-70878000 vmuh.d                 VdVjVk
-70880000 vmuh.bu                VdVjVk
-70888000 vmuh.hu                VdVjVk
-70890000 vmuh.wu                VdVjVk
-70898000 vmuh.du                VdVjVk
-70900000 vmulwev.h.b            VdVjVk
-70908000 vmulwev.w.h            VdVjVk
-70910000 vmulwev.d.w            VdVjVk
-70918000 vmulwev.q.d            VdVjVk
-70920000 vmulwod.h.b            VdVjVk
-70928000 vmulwod.w.h            VdVjVk
-70930000 vmulwod.d.w            VdVjVk
-70938000 vmulwod.q.d            VdVjVk
-70980000 vmulwev.h.bu           VdVjVk
-70988000 vmulwev.w.hu           VdVjVk
-70990000 vmulwev.d.wu           VdVjVk
-70998000 vmulwev.q.du           VdVjVk
-709a0000 vmulwod.h.bu           VdVjVk
-709a8000 vmulwod.w.hu           VdVjVk
-709b0000 vmulwod.d.wu           VdVjVk
-709b8000 vmulwod.q.du           VdVjVk
-70a00000 vmulwev.h.bu.b         VdVjVk
-70a08000 vmulwev.w.hu.h         VdVjVk
-70a10000 vmulwev.d.wu.w         VdVjVk
-70a18000 vmulwev.q.du.d         VdVjVk
-70a20000 vmulwod.h.bu.b         VdVjVk
-70a28000 vmulwod.w.hu.h         VdVjVk
-70a30000 vmulwod.d.wu.w         VdVjVk
-70a38000 vmulwod.q.du.d         VdVjVk
-70a80000 vmadd.b                VdVjVk
-70a88000 vmadd.h                VdVjVk
-70a90000 vmadd.w                VdVjVk
-70a98000 vmadd.d                VdVjVk
-70aa0000 vmsub.b                VdVjVk
-70aa8000 vmsub.h                VdVjVk
-70ab0000 vmsub.w                VdVjVk
-70ab8000 vmsub.d                VdVjVk
-70ac0000 vmaddwev.h.b           VdVjVk
-70ac8000 vmaddwev.w.h           VdVjVk
-70ad0000 vmaddwev.d.w           VdVjVk
-70ad8000 vmaddwev.q.d           VdVjVk
-70ae0000 vmaddwod.h.b           VdVjVk
-70ae8000 vmaddwod.w.h           VdVjVk
-70af0000 vmaddwod.d.w           VdVjVk
-70af8000 vmaddwod.q.d           VdVjVk
-70b40000 vmaddwev.h.bu          VdVjVk
-70b48000 vmaddwev.w.hu          VdVjVk
-70b50000 vmaddwev.d.wu          VdVjVk
-70b58000 vmaddwev.q.du          VdVjVk
-70b60000 vmaddwod.h.bu          VdVjVk
-70b68000 vmaddwod.w.hu          VdVjVk
-70b70000 vmaddwod.d.wu          VdVjVk
-70b78000 vmaddwod.q.du          VdVjVk
-70bc0000 vmaddwev.h.bu.b        VdVjVk
-70bc8000 vmaddwev.w.hu.h        VdVjVk
-70bd0000 vmaddwev.d.wu.w        VdVjVk
-70bd8000 vmaddwev.q.du.d        VdVjVk
-70be0000 vmaddwod.h.bu.b        VdVjVk
-70be8000 vmaddwod.w.hu.h        VdVjVk
-70bf0000 vmaddwod.d.wu.w        VdVjVk
-70bf8000 vmaddwod.q.du.d        VdVjVk
-70e00000 vdiv.b                 VdVjVk
-70e08000 vdiv.h                 VdVjVk
-70e10000 vdiv.w                 VdVjVk
-70e18000 vdiv.d                 VdVjVk
-70e20000 vmod.b                 VdVjVk
-70e28000 vmod.h                 VdVjVk
-70e30000 vmod.w                 VdVjVk
-70e38000 vmod.d                 VdVjVk
-70e40000 vdiv.bu                VdVjVk
-70e48000 vdiv.hu                VdVjVk
-70e50000 vdiv.wu                VdVjVk
-70e58000 vdiv.du                VdVjVk
-70e60000 vmod.bu                VdVjVk
-70e68000 vmod.hu                VdVjVk
-70e70000 vmod.wu                VdVjVk
-70e78000 vmod.du                VdVjVk
-70e80000 vsll.b                 VdVjVk          @qemu
-70e88000 vsll.h                 VdVjVk          @qemu
-70e90000 vsll.w                 VdVjVk          @qemu
-70e98000 vsll.d                 VdVjVk          @qemu
-70ea0000 vsrl.b                 VdVjVk          @qemu
-70ea8000 vsrl.h                 VdVjVk          @qemu
-70eb0000 vsrl.w                 VdVjVk          @qemu
-70eb8000 vsrl.d                 VdVjVk          @qemu
-70ec0000 vsra.b                 VdVjVk          @qemu
-70ec8000 vsra.h                 VdVjVk          @qemu
-70ed0000 vsra.w                 VdVjVk          @qemu
-70ed8000 vsra.d                 VdVjVk          @qemu
-70ee0000 vrotr.b                VdVjVk          @qemu
-70ee8000 vrotr.h                VdVjVk          @qemu
-70ef0000 vrotr.w                VdVjVk          @qemu
-70ef8000 vrotr.d                VdVjVk          @qemu
-70f00000 vsrlr.b                VdVjVk
-70f08000 vsrlr.h                VdVjVk
-70f10000 vsrlr.w                VdVjVk
-70f18000 vsrlr.d                VdVjVk
-70f20000 vsrar.b                VdVjVk
-70f28000 vsrar.h                VdVjVk
-70f30000 vsrar.w                VdVjVk
-70f38000 vsrar.d                VdVjVk
-70f48000 vsrln.b.h              VdVjVk
-70f50000 vsrln.h.w              VdVjVk
-70f58000 vsrln.w.d              VdVjVk
-70f68000 vsran.b.h              VdVjVk
-70f70000 vsran.h.w              VdVjVk
-70f78000 vsran.w.d              VdVjVk
-70f88000 vsrlrn.b.h             VdVjVk
-70f90000 vsrlrn.h.w             VdVjVk
-70f98000 vsrlrn.w.d             VdVjVk
-70fa8000 vsrarn.b.h             VdVjVk
-70fb0000 vsrarn.h.w             VdVjVk
-70fb8000 vsrarn.w.d             VdVjVk
-70fc8000 vssrln.b.h             VdVjVk
-70fd0000 vssrln.h.w             VdVjVk
-70fd8000 vssrln.w.d             VdVjVk
-70fe8000 vssran.b.h             VdVjVk
-70ff0000 vssran.h.w             VdVjVk
-70ff8000 vssran.w.d             VdVjVk
-71008000 vssrlrn.b.h            VdVjVk
-71010000 vssrlrn.h.w            VdVjVk
-71018000 vssrlrn.w.d            VdVjVk
-71028000 vssrarn.b.h            VdVjVk
-71030000 vssrarn.h.w            VdVjVk
-71038000 vssrarn.w.d            VdVjVk
-71048000 vssrln.bu.h            VdVjVk
-71050000 vssrln.hu.w            VdVjVk
-71058000 vssrln.wu.d            VdVjVk
-71068000 vssran.bu.h            VdVjVk
-71070000 vssran.hu.w            VdVjVk
-71078000 vssran.wu.d            VdVjVk
-71088000 vssrlrn.bu.h           VdVjVk
-71090000 vssrlrn.hu.w           VdVjVk
-71098000 vssrlrn.wu.d           VdVjVk
-710a8000 vssrarn.bu.h           VdVjVk
-710b0000 vssrarn.hu.w           VdVjVk
-710b8000 vssrarn.wu.d           VdVjVk
-710c0000 vbitclr.b              VdVjVk
-710c8000 vbitclr.h              VdVjVk
-710d0000 vbitclr.w              VdVjVk
-710d8000 vbitclr.d              VdVjVk
-710e0000 vbitset.b              VdVjVk
-710e8000 vbitset.h              VdVjVk
-710f0000 vbitset.w              VdVjVk
-710f8000 vbitset.d              VdVjVk
-71100000 vbitrev.b              VdVjVk
-71108000 vbitrev.h              VdVjVk
-71110000 vbitrev.w              VdVjVk
-71118000 vbitrev.d              VdVjVk
-71160000 vpackev.b              VdVjVk
-71168000 vpackev.h              VdVjVk
-71170000 vpackev.w              VdVjVk
-71178000 vpackev.d              VdVjVk
-71180000 vpackod.b              VdVjVk
-71188000 vpackod.h              VdVjVk
-71190000 vpackod.w              VdVjVk
-71198000 vpackod.d              VdVjVk
-711a0000 vilvl.b                VdVjVk
-711a8000 vilvl.h                VdVjVk
-711b0000 vilvl.w                VdVjVk
-711b8000 vilvl.d                VdVjVk
-711c0000 vilvh.b                VdVjVk
-711c8000 vilvh.h                VdVjVk
-711d0000 vilvh.w                VdVjVk
-711d8000 vilvh.d                VdVjVk
-711e0000 vpickev.b              VdVjVk
-711e8000 vpickev.h              VdVjVk
-711f0000 vpickev.w              VdVjVk
-711f8000 vpickev.d              VdVjVk
-71200000 vpickod.b              VdVjVk
-71208000 vpickod.h              VdVjVk
-71210000 vpickod.w              VdVjVk
-71218000 vpickod.d              VdVjVk
-71220000 vreplve.b              VdVjK           @qemu
-71228000 vreplve.h              VdVjK           @qemu
-71230000 vreplve.w              VdVjK           @qemu
-71238000 vreplve.d              VdVjK           @qemu
-71260000 vand.v                 VdVjVk          @qemu
-71268000 vor.v                  VdVjVk          @qemu
-71270000 vxor.v                 VdVjVk          @qemu
-71278000 vnor.v                 VdVjVk          @qemu
-71280000 vandn.v                VdVjVk          @qemu
-71288000 vorn.v                 VdVjVk          @qemu
-712b0000 vfrstp.b               VdVjVk
-712b8000 vfrstp.h               VdVjVk
-712d0000 vadd.q                 VdVjVk
-712d8000 vsub.q                 VdVjVk
-712e0000 vsigncov.b             VdVjVk
-712e8000 vsigncov.h             VdVjVk
-712f0000 vsigncov.w             VdVjVk
-712f8000 vsigncov.d             VdVjVk
-71308000 vfadd.s                VdVjVk
-71310000 vfadd.d                VdVjVk
-71328000 vfsub.s                VdVjVk
-71330000 vfsub.d                VdVjVk
-71388000 vfmul.s                VdVjVk
-71390000 vfmul.d                VdVjVk
-713a8000 vfdiv.s                VdVjVk
-713b0000 vfdiv.d                VdVjVk
-713c8000 vfmax.s                VdVjVk
-713d0000 vfmax.d                VdVjVk
-713e8000 vfmin.s                VdVjVk
-713f0000 vfmin.d                VdVjVk
-71408000 vfmaxa.s               VdVjVk
-71410000 vfmaxa.d               VdVjVk
-71428000 vfmina.s               VdVjVk
-71430000 vfmina.d               VdVjVk
-71460000 vfcvt.h.s              VdVjVk
-71468000 vfcvt.s.d              VdVjVk
-71480000 vffint.s.l             VdVjVk
-71498000 vftint.w.d             VdVjVk
-714a0000 vftintrm.w.d           VdVjVk
-714a8000 vftintrp.w.d           VdVjVk
-714b0000 vftintrz.w.d           VdVjVk
-714b8000 vftintrne.w.d          VdVjVk
-717a8000 vshuf.h                VdVjVk
-717b0000 vshuf.w                VdVjVk
-717b8000 vshuf.d                VdVjVk
-72800000 vseqi.b                VdVjSk5         @qemu
-72808000 vseqi.h                VdVjSk5         @qemu
-72810000 vseqi.w                VdVjSk5         @qemu
-72818000 vseqi.d                VdVjSk5         @qemu
-72820000 vslei.b                VdVjSk5         @qemu
-72828000 vslei.h                VdVjSk5         @qemu
-72830000 vslei.w                VdVjSk5         @qemu
-72838000 vslei.d                VdVjSk5         @qemu
-72840000 vslei.bu               VdVjUk5         @qemu
-72848000 vslei.hu               VdVjUk5         @qemu
-72850000 vslei.wu               VdVjUk5         @qemu
-72858000 vslei.du               VdVjUk5         @qemu
-72860000 vslti.b                VdVjSk5         @qemu
-72868000 vslti.h                VdVjSk5         @qemu
-72870000 vslti.w                VdVjSk5         @qemu
-72878000 vslti.d                VdVjSk5         @qemu
-72880000 vslti.bu               VdVjUk5         @qemu
-72888000 vslti.hu               VdVjUk5         @qemu
-72890000 vslti.wu               VdVjUk5         @qemu
-72898000 vslti.du               VdVjUk5         @qemu
-728a0000 vaddi.bu               VdVjUk5         @qemu
-728a8000 vaddi.hu               VdVjUk5         @qemu
-728b0000 vaddi.wu               VdVjUk5         @qemu
-728b8000 vaddi.du               VdVjUk5         @qemu
-728c0000 vsubi.bu               VdVjUk5         @qemu
-728c8000 vsubi.hu               VdVjUk5         @qemu
-728d0000 vsubi.wu               VdVjUk5         @qemu
-728d8000 vsubi.du               VdVjUk5         @qemu
-728e0000 vbsll.v                VdVjUk5
-728e8000 vbsrl.v                VdVjUk5
-72900000 vmaxi.b                VdVjSk5         @qemu
-72908000 vmaxi.h                VdVjSk5         @qemu
-72910000 vmaxi.w                VdVjSk5         @qemu
-72918000 vmaxi.d                VdVjSk5         @qemu
-72920000 vmini.b                VdVjSk5         @qemu
-72928000 vmini.h                VdVjSk5         @qemu
-72930000 vmini.w                VdVjSk5         @qemu
-72938000 vmini.d                VdVjSk5         @qemu
-72940000 vmaxi.bu               VdVjUk5         @qemu
-72948000 vmaxi.hu               VdVjUk5         @qemu
-72950000 vmaxi.wu               VdVjUk5         @qemu
-72958000 vmaxi.du               VdVjUk5         @qemu
-72960000 vmini.bu               VdVjUk5         @qemu
-72968000 vmini.hu               VdVjUk5         @qemu
-72970000 vmini.wu               VdVjUk5         @qemu
-72978000 vmini.du               VdVjUk5         @qemu
-729a0000 vfrstpi.b              VdVjUk5
-729a8000 vfrstpi.h              VdVjUk5
-729b8000 vmepatmsk.v            VdUj5Uk5
-729c0000 vclo.b                 VdVj
-729c0400 vclo.h                 VdVj
-729c0800 vclo.w                 VdVj
-729c0c00 vclo.d                 VdVj
-729c1000 vclz.b                 VdVj
-729c1400 vclz.h                 VdVj
-729c1800 vclz.w                 VdVj
-729c1c00 vclz.d                 VdVj
-729c2000 vpcnt.b                VdVj
-729c2400 vpcnt.h                VdVj
-729c2800 vpcnt.w                VdVj
-729c2c00 vpcnt.d                VdVj
-729c3000 vneg.b                 VdVj            @qemu
-729c3400 vneg.h                 VdVj            @qemu
-729c3800 vneg.w                 VdVj            @qemu
-729c3c00 vneg.d                 VdVj            @qemu
-729c4000 vmskltz.b              VdVj
-729c4400 vmskltz.h              VdVj
-729c4800 vmskltz.w              VdVj
-729c4c00 vmskltz.d              VdVj
-729c5000 vmskgez.b              VdVj
-729c6000 vmsknz.b               VdVj
-729c9800 vseteqz.v              CdVj
-729c9c00 vsetnez.v              CdVj
-729ca000 vsetanyeqz.b           CdVj
-729ca400 vsetanyeqz.h           CdVj
-729ca800 vsetanyeqz.w           CdVj
-729cac00 vsetanyeqz.d           CdVj
-729cb000 vsetallnez.b           CdVj
-729cb400 vsetallnez.h           CdVj
-729cb800 vsetallnez.w           CdVj
-729cbc00 vsetallnez.d           CdVj
-729cc400 vflogb.s               VdVj
-729cc800 vflogb.d               VdVj
-729cd400 vfclass.s              VdVj
-729cd800 vfclass.d              VdVj
-729ce400 vfsqrt.s               VdVj
-729ce800 vfsqrt.d               VdVj
-729cf400 vfrecip.s              VdVj
-729cf800 vfrecip.d              VdVj
-729d0400 vfrsqrt.s              VdVj
-729d0800 vfrsqrt.d              VdVj
-729d1400 vfrecipe.s             VdVj            @rev=1p10
-729d1800 vfrecipe.d             VdVj            @rev=1p10
-729d2400 vfrsqrte.s             VdVj            @rev=1p10
-729d2800 vfrsqrte.d             VdVj            @rev=1p10
-729d3400 vfrint.s               VdVj
-729d3800 vfrint.d               VdVj
-729d4400 vfrintrm.s             VdVj
-729d4800 vfrintrm.d             VdVj
-729d5400 vfrintrp.s             VdVj
-729d5800 vfrintrp.d             VdVj
-729d6400 vfrintrz.s             VdVj
-729d6800 vfrintrz.d             VdVj
-729d7400 vfrintrne.s            VdVj
-729d7800 vfrintrne.d            VdVj
-729de800 vfcvtl.s.h             VdVj
-729dec00 vfcvth.s.h             VdVj
-729df000 vfcvtl.d.s             VdVj
-729df400 vfcvth.d.s             VdVj
-729e0000 vffint.s.w             VdVj
-729e0400 vffint.s.wu            VdVj
-729e0800 vffint.d.l             VdVj
-729e0c00 vffint.d.lu            VdVj
-729e1000 vffintl.d.w            VdVj
-729e1400 vffinth.d.w            VdVj
-729e3000 vftint.w.s             VdVj
-729e3400 vftint.l.d             VdVj
-729e3800 vftintrm.w.s           VdVj
-729e3c00 vftintrm.l.d           VdVj
-729e4000 vftintrp.w.s           VdVj
-729e4400 vftintrp.l.d           VdVj
-729e4800 vftintrz.w.s           VdVj
-729e4c00 vftintrz.l.d           VdVj
-729e5000 vftintrne.w.s          VdVj
-729e5400 vftintrne.l.d          VdVj
-729e5800 vftint.wu.s            VdVj
-729e5c00 vftint.lu.d            VdVj
-729e7000 vftintrz.wu.s          VdVj
-729e7400 vftintrz.lu.d          VdVj
-729e8000 vftintl.l.s            VdVj
-729e8400 vftinth.l.s            VdVj
-729e8800 vftintrml.l.s          VdVj
-729e8c00 vftintrmh.l.s          VdVj
-729e9000 vftintrpl.l.s          VdVj
-729e9400 vftintrph.l.s          VdVj
-729e9800 vftintrzl.l.s          VdVj
-729e9c00 vftintrzh.l.s          VdVj
-729ea000 vftintrnel.l.s         VdVj
-729ea400 vftintrneh.l.s         VdVj
-729ee000 vexth.h.b              VdVj
-729ee400 vexth.w.h              VdVj
-729ee800 vexth.d.w              VdVj
-729eec00 vexth.q.d              VdVj
-729ef000 vexth.hu.bu            VdVj
-729ef400 vexth.wu.hu            VdVj
-729ef800 vexth.du.wu            VdVj
-729efc00 vexth.qu.du            VdVj
-729f0000 vreplgr2vr.b           VdJ             @qemu
-729f0400 vreplgr2vr.h           VdJ             @qemu
-729f0800 vreplgr2vr.w           VdJ             @qemu
-729f0c00 vreplgr2vr.d           VdJ             @qemu
-72a02000 vrotri.b               VdVjUk3         @qemu
-72a04000 vrotri.h               VdVjUk4         @qemu
-72a08000 vrotri.w               VdVjUk5         @qemu
-72a10000 vrotri.d               VdVjUk6         @qemu
-72a42000 vsrlri.b               VdVjUk3
-72a44000 vsrlri.h               VdVjUk4
-72a48000 vsrlri.w               VdVjUk5
-72a50000 vsrlri.d               VdVjUk6
-72a82000 vsrari.b               VdVjUk3
-72a84000 vsrari.h               VdVjUk4
-72a88000 vsrari.w               VdVjUk5
-72a90000 vsrari.d               VdVjUk6
-72eb8000 vinsgr2vr.b            VdJUk4          @qemu
-72ebc000 vinsgr2vr.h            VdJUk3          @qemu
-72ebe000 vinsgr2vr.w            VdJUk2          @qemu
-72ebf000 vinsgr2vr.d            VdJUk1          @qemu
-72ef8000 vpickve2gr.b           DVjUk4          @qemu
-72efc000 vpickve2gr.h           DVjUk3          @qemu
-72efe000 vpickve2gr.w           DVjUk2          @qemu
-72eff000 vpickve2gr.d           DVjUk1          @qemu
-72f38000 vpickve2gr.bu          DVjUk4          @qemu
-72f3c000 vpickve2gr.hu          DVjUk3          @qemu
-72f3e000 vpickve2gr.wu          DVjUk2          @qemu
-72f3f000 vpickve2gr.du          DVjUk1          @qemu
-72f78000 vreplvei.b             VdVjUk4         @qemu
-72f7c000 vreplvei.h             VdVjUk3         @qemu
-72f7e000 vreplvei.w             VdVjUk2         @qemu
-72f7f000 vreplvei.d             VdVjUk1         @qemu
-73082000 vsllwil.h.b            VdVjUk3
-73084000 vsllwil.w.h            VdVjUk4
-73088000 vsllwil.d.w            VdVjUk5
-73090000 vextl.q.d              VdVj
-730c2000 vsllwil.hu.bu          VdVjUk3
-730c4000 vsllwil.wu.hu          VdVjUk4
-730c8000 vsllwil.du.wu          VdVjUk5
-730d0000 vextl.qu.du            VdVj
-73102000 vbitclri.b             VdVjUk3         @qemu
-73104000 vbitclri.h             VdVjUk4         @qemu
-73108000 vbitclri.w             VdVjUk5         @qemu
-73110000 vbitclri.d             VdVjUk6         @qemu
-73142000 vbitseti.b             VdVjUk3         @qemu
-73144000 vbitseti.h             VdVjUk4         @qemu
-73148000 vbitseti.w             VdVjUk5         @qemu
-73150000 vbitseti.d             VdVjUk6         @qemu
-73182000 vbitrevi.b             VdVjUk3         @qemu
-73184000 vbitrevi.h             VdVjUk4         @qemu
-73188000 vbitrevi.w             VdVjUk5         @qemu
-73190000 vbitrevi.d             VdVjUk6         @qemu
-73242000 vsat.b                 VdVjUk3
-73244000 vsat.h                 VdVjUk4
-73248000 vsat.w                 VdVjUk5
-73250000 vsat.d                 VdVjUk6
-73282000 vsat.bu                VdVjUk3
-73284000 vsat.hu                VdVjUk4
-73288000 vsat.wu                VdVjUk5
-73290000 vsat.du                VdVjUk6
-732c2000 vslli.b                VdVjUk3         @qemu
-732c4000 vslli.h                VdVjUk4         @qemu
-732c8000 vslli.w                VdVjUk5         @qemu
-732d0000 vslli.d                VdVjUk6         @qemu
-73302000 vsrli.b                VdVjUk3         @qemu
-73304000 vsrli.h                VdVjUk4         @qemu
-73308000 vsrli.w                VdVjUk5         @qemu
-73310000 vsrli.d                VdVjUk6         @qemu
-73342000 vsrai.b                VdVjUk3         @qemu
-73344000 vsrai.h                VdVjUk4         @qemu
-73348000 vsrai.w                VdVjUk5         @qemu
-73350000 vsrai.d                VdVjUk6         @qemu
-73404000 vsrlni.b.h             VdVjUk4
-73408000 vsrlni.h.w             VdVjUk5
-73410000 vsrlni.w.d             VdVjUk6
-73420000 vsrlni.d.q             VdVjUk7
-73444000 vsrlrni.b.h            VdVjUk4
-73448000 vsrlrni.h.w            VdVjUk5
-73450000 vsrlrni.w.d            VdVjUk6
-73460000 vsrlrni.d.q            VdVjUk7
-73484000 vssrlni.b.h            VdVjUk4
-73488000 vssrlni.h.w            VdVjUk5
-73490000 vssrlni.w.d            VdVjUk6
-734a0000 vssrlni.d.q            VdVjUk7
-734c4000 vssrlni.bu.h           VdVjUk4
-734c8000 vssrlni.hu.w           VdVjUk5
-734d0000 vssrlni.wu.d           VdVjUk6
-734e0000 vssrlni.du.q           VdVjUk7
-73504000 vssrlrni.b.h           VdVjUk4
-73508000 vssrlrni.h.w           VdVjUk5
-73510000 vssrlrni.w.d           VdVjUk6
-73520000 vssrlrni.d.q           VdVjUk7
-73544000 vssrlrni.bu.h          VdVjUk4
-73548000 vssrlrni.hu.w          VdVjUk5
-73550000 vssrlrni.wu.d          VdVjUk6
-73560000 vssrlrni.du.q          VdVjUk7
-73584000 vsrani.b.h             VdVjUk4
-73588000 vsrani.h.w             VdVjUk5
-73590000 vsrani.w.d             VdVjUk6
-735a0000 vsrani.d.q             VdVjUk7
-735c4000 vsrarni.b.h            VdVjUk4
-735c8000 vsrarni.h.w            VdVjUk5
-735d0000 vsrarni.w.d            VdVjUk6
-735e0000 vsrarni.d.q            VdVjUk7
-73604000 vssrani.b.h            VdVjUk4
-73608000 vssrani.h.w            VdVjUk5
-73610000 vssrani.w.d            VdVjUk6
-73620000 vssrani.d.q            VdVjUk7
-73644000 vssrani.bu.h           VdVjUk4
-73648000 vssrani.hu.w           VdVjUk5
-73650000 vssrani.wu.d           VdVjUk6
-73660000 vssrani.du.q           VdVjUk7
-73684000 vssrarni.b.h           VdVjUk4
-73688000 vssrarni.h.w           VdVjUk5
-73690000 vssrarni.w.d           VdVjUk6
-736a0000 vssrarni.d.q           VdVjUk7
-736c4000 vssrarni.bu.h          VdVjUk4
-736c8000 vssrarni.hu.w          VdVjUk5
-736d0000 vssrarni.wu.d          VdVjUk6
-736e0000 vssrarni.du.q          VdVjUk7
-73800000 vextrins.d             VdVjUk8
-73840000 vextrins.w             VdVjUk8
-73880000 vextrins.h             VdVjUk8
-738c0000 vextrins.b             VdVjUk8
-73900000 vshuf4i.b              VdVjUk8
-73940000 vshuf4i.h              VdVjUk8
-73980000 vshuf4i.w              VdVjUk8
-739c0000 vshuf4i.d              VdVjUk8
-73c40000 vbitseli.b             VdVjUk8         @qemu
-73d00000 vandi.b                VdVjUk8         @qemu
-73d40000 vori.b                 VdVjUk8         @qemu
-73d80000 vxori.b                VdVjUk8         @qemu
-73dc0000 vnori.b                VdVjUk8         @qemu
-73e00000 vldi                   VdSj13          @qemu
-73e40000 vpermi.w               VdVjUk8
+70000000 vseq.b                 VdVjVk          @qemu @modify=Vd
+70008000 vseq.h                 VdVjVk          @qemu @modify=Vd
+70010000 vseq.w                 VdVjVk          @qemu @modify=Vd
+70018000 vseq.d                 VdVjVk          @qemu @modify=Vd
+70020000 vsle.b                 VdVjVk          @qemu @modify=Vd
+70028000 vsle.h                 VdVjVk          @qemu @modify=Vd
+70030000 vsle.w                 VdVjVk          @qemu @modify=Vd
+70038000 vsle.d                 VdVjVk          @qemu @modify=Vd
+70040000 vsle.bu                VdVjVk          @qemu @modify=Vd
+70048000 vsle.hu                VdVjVk          @qemu @modify=Vd
+70050000 vsle.wu                VdVjVk          @qemu @modify=Vd
+70058000 vsle.du                VdVjVk          @qemu @modify=Vd
+70060000 vslt.b                 VdVjVk          @qemu @modify=Vd
+70068000 vslt.h                 VdVjVk          @qemu @modify=Vd
+70070000 vslt.w                 VdVjVk          @qemu @modify=Vd
+70078000 vslt.d                 VdVjVk          @qemu @modify=Vd
+70080000 vslt.bu                VdVjVk          @qemu @modify=Vd
+70088000 vslt.hu                VdVjVk          @qemu @modify=Vd
+70090000 vslt.wu                VdVjVk          @qemu @modify=Vd
+70098000 vslt.du                VdVjVk          @qemu @modify=Vd
+700a0000 vadd.b                 VdVjVk          @qemu @modify=Vd
+700a8000 vadd.h                 VdVjVk          @qemu @modify=Vd
+700b0000 vadd.w                 VdVjVk          @qemu @modify=Vd
+700b8000 vadd.d                 VdVjVk          @qemu @modify=Vd
+700c0000 vsub.b                 VdVjVk          @qemu @modify=Vd
+700c8000 vsub.h                 VdVjVk          @qemu @modify=Vd
+700d0000 vsub.w                 VdVjVk          @qemu @modify=Vd
+700d8000 vsub.d                 VdVjVk          @qemu @modify=Vd
+701e0000 vaddwev.h.b            VdVjVk          @modify=Vd
+701e8000 vaddwev.w.h            VdVjVk          @modify=Vd
+701f0000 vaddwev.d.w            VdVjVk          @modify=Vd
+701f8000 vaddwev.q.d            VdVjVk          @modify=Vd
+70200000 vsubwev.h.b            VdVjVk          @modify=Vd
+70208000 vsubwev.w.h            VdVjVk          @modify=Vd
+70210000 vsubwev.d.w            VdVjVk          @modify=Vd
+70218000 vsubwev.q.d            VdVjVk          @modify=Vd
+70220000 vaddwod.h.b            VdVjVk          @modify=Vd
+70228000 vaddwod.w.h            VdVjVk          @modify=Vd
+70230000 vaddwod.d.w            VdVjVk          @modify=Vd
+70238000 vaddwod.q.d            VdVjVk          @modify=Vd
+70240000 vsubwod.h.b            VdVjVk          @modify=Vd
+70248000 vsubwod.w.h            VdVjVk          @modify=Vd
+70250000 vsubwod.d.w            VdVjVk          @modify=Vd
+70258000 vsubwod.q.d            VdVjVk          @modify=Vd
+702e0000 vaddwev.h.bu           VdVjVk          @modify=Vd
+702e8000 vaddwev.w.hu           VdVjVk          @modify=Vd
+702f0000 vaddwev.d.wu           VdVjVk          @modify=Vd
+702f8000 vaddwev.q.du           VdVjVk          @modify=Vd
+70300000 vsubwev.h.bu           VdVjVk          @modify=Vd
+70308000 vsubwev.w.hu           VdVjVk          @modify=Vd
+70310000 vsubwev.d.wu           VdVjVk          @modify=Vd
+70318000 vsubwev.q.du           VdVjVk          @modify=Vd
+70320000 vaddwod.h.bu           VdVjVk          @modify=Vd
+70328000 vaddwod.w.hu           VdVjVk          @modify=Vd
+70330000 vaddwod.d.wu           VdVjVk          @modify=Vd
+70338000 vaddwod.q.du           VdVjVk          @modify=Vd
+70340000 vsubwod.h.bu           VdVjVk          @modify=Vd
+70348000 vsubwod.w.hu           VdVjVk          @modify=Vd
+70350000 vsubwod.d.wu           VdVjVk          @modify=Vd
+70358000 vsubwod.q.du           VdVjVk          @modify=Vd
+703e0000 vaddwev.h.bu.b         VdVjVk          @modify=Vd
+703e8000 vaddwev.w.hu.h         VdVjVk          @modify=Vd
+703f0000 vaddwev.d.wu.w         VdVjVk          @modify=Vd
+703f8000 vaddwev.q.du.d         VdVjVk          @modify=Vd
+70400000 vaddwod.h.bu.b         VdVjVk          @modify=Vd
+70408000 vaddwod.w.hu.h         VdVjVk          @modify=Vd
+70410000 vaddwod.d.wu.w         VdVjVk          @modify=Vd
+70418000 vaddwod.q.du.d         VdVjVk          @modify=Vd
+70460000 vsadd.b                VdVjVk          @qemu @modify=Vd
+70468000 vsadd.h                VdVjVk          @qemu @modify=Vd
+70470000 vsadd.w                VdVjVk          @qemu @modify=Vd
+70478000 vsadd.d                VdVjVk          @qemu @modify=Vd
+70480000 vssub.b                VdVjVk          @qemu @modify=Vd
+70488000 vssub.h                VdVjVk          @qemu @modify=Vd
+70490000 vssub.w                VdVjVk          @qemu @modify=Vd
+70498000 vssub.d                VdVjVk          @qemu @modify=Vd
+704a0000 vsadd.bu               VdVjVk          @qemu @modify=Vd
+704a8000 vsadd.hu               VdVjVk          @qemu @modify=Vd
+704b0000 vsadd.wu               VdVjVk          @qemu @modify=Vd
+704b8000 vsadd.du               VdVjVk          @qemu @modify=Vd
+704c0000 vssub.bu               VdVjVk          @qemu @modify=Vd
+704c8000 vssub.hu               VdVjVk          @qemu @modify=Vd
+704d0000 vssub.wu               VdVjVk          @qemu @modify=Vd
+704d8000 vssub.du               VdVjVk          @qemu @modify=Vd
+70540000 vhaddw.h.b             VdVjVk          @modify=Vd
+70548000 vhaddw.w.h             VdVjVk          @modify=Vd
+70550000 vhaddw.d.w             VdVjVk          @modify=Vd
+70558000 vhaddw.q.d             VdVjVk          @modify=Vd
+70560000 vhsubw.h.b             VdVjVk          @modify=Vd
+70568000 vhsubw.w.h             VdVjVk          @modify=Vd
+70570000 vhsubw.d.w             VdVjVk          @modify=Vd
+70578000 vhsubw.q.d             VdVjVk          @modify=Vd
+70580000 vhaddw.hu.bu           VdVjVk          @modify=Vd
+70588000 vhaddw.wu.hu           VdVjVk          @modify=Vd
+70590000 vhaddw.du.wu           VdVjVk          @modify=Vd
+70598000 vhaddw.qu.du           VdVjVk          @modify=Vd
+705a0000 vhsubw.hu.bu           VdVjVk          @modify=Vd
+705a8000 vhsubw.wu.hu           VdVjVk          @modify=Vd
+705b0000 vhsubw.du.wu           VdVjVk          @modify=Vd
+705b8000 vhsubw.qu.du           VdVjVk          @modify=Vd
+705c0000 vadda.b                VdVjVk          @modify=Vd
+705c8000 vadda.h                VdVjVk          @modify=Vd
+705d0000 vadda.w                VdVjVk          @modify=Vd
+705d8000 vadda.d                VdVjVk          @modify=Vd
+70600000 vabsd.b                VdVjVk          @modify=Vd
+70608000 vabsd.h                VdVjVk          @modify=Vd
+70610000 vabsd.w                VdVjVk          @modify=Vd
+70618000 vabsd.d                VdVjVk          @modify=Vd
+70620000 vabsd.bu               VdVjVk          @modify=Vd
+70628000 vabsd.hu               VdVjVk          @modify=Vd
+70630000 vabsd.wu               VdVjVk          @modify=Vd
+70638000 vabsd.du               VdVjVk          @modify=Vd
+70640000 vavg.b                 VdVjVk          @modify=Vd
+70648000 vavg.h                 VdVjVk          @modify=Vd
+70650000 vavg.w                 VdVjVk          @modify=Vd
+70658000 vavg.d                 VdVjVk          @modify=Vd
+70660000 vavg.bu                VdVjVk          @modify=Vd
+70668000 vavg.hu                VdVjVk          @modify=Vd
+70670000 vavg.wu                VdVjVk          @modify=Vd
+70678000 vavg.du                VdVjVk          @modify=Vd
+70680000 vavgr.b                VdVjVk          @modify=Vd
+70688000 vavgr.h                VdVjVk          @modify=Vd
+70690000 vavgr.w                VdVjVk          @modify=Vd
+70698000 vavgr.d                VdVjVk          @modify=Vd
+706a0000 vavgr.bu               VdVjVk          @modify=Vd
+706a8000 vavgr.hu               VdVjVk          @modify=Vd
+706b0000 vavgr.wu               VdVjVk          @modify=Vd
+706b8000 vavgr.du               VdVjVk          @modify=Vd
+70700000 vmax.b                 VdVjVk          @qemu @modify=Vd
+70708000 vmax.h                 VdVjVk          @qemu @modify=Vd
+70710000 vmax.w                 VdVjVk          @qemu @modify=Vd
+70718000 vmax.d                 VdVjVk          @qemu @modify=Vd
+70720000 vmin.b                 VdVjVk          @qemu @modify=Vd
+70728000 vmin.h                 VdVjVk          @qemu @modify=Vd
+70730000 vmin.w                 VdVjVk          @qemu @modify=Vd
+70738000 vmin.d                 VdVjVk          @qemu @modify=Vd
+70740000 vmax.bu                VdVjVk          @qemu @modify=Vd
+70748000 vmax.hu                VdVjVk          @qemu @modify=Vd
+70750000 vmax.wu                VdVjVk          @qemu @modify=Vd
+70758000 vmax.du                VdVjVk          @qemu @modify=Vd
+70760000 vmin.bu                VdVjVk          @qemu @modify=Vd
+70768000 vmin.hu                VdVjVk          @qemu @modify=Vd
+70770000 vmin.wu                VdVjVk          @qemu @modify=Vd
+70778000 vmin.du                VdVjVk          @qemu @modify=Vd
+70840000 vmul.b                 VdVjVk          @qemu @modify=Vd
+70848000 vmul.h                 VdVjVk          @qemu @modify=Vd
+70850000 vmul.w                 VdVjVk          @qemu @modify=Vd
+70858000 vmul.d                 VdVjVk          @qemu @modify=Vd
+70860000 vmuh.b                 VdVjVk          @modify=Vd
+70868000 vmuh.h                 VdVjVk          @modify=Vd
+70870000 vmuh.w                 VdVjVk          @modify=Vd
+70878000 vmuh.d                 VdVjVk          @modify=Vd
+70880000 vmuh.bu                VdVjVk          @modify=Vd
+70888000 vmuh.hu                VdVjVk          @modify=Vd
+70890000 vmuh.wu                VdVjVk          @modify=Vd
+70898000 vmuh.du                VdVjVk          @modify=Vd
+70900000 vmulwev.h.b            VdVjVk          @modify=Vd
+70908000 vmulwev.w.h            VdVjVk          @modify=Vd
+70910000 vmulwev.d.w            VdVjVk          @modify=Vd
+70918000 vmulwev.q.d            VdVjVk          @modify=Vd
+70920000 vmulwod.h.b            VdVjVk          @modify=Vd
+70928000 vmulwod.w.h            VdVjVk          @modify=Vd
+70930000 vmulwod.d.w            VdVjVk          @modify=Vd
+70938000 vmulwod.q.d            VdVjVk          @modify=Vd
+70980000 vmulwev.h.bu           VdVjVk          @modify=Vd
+70988000 vmulwev.w.hu           VdVjVk          @modify=Vd
+70990000 vmulwev.d.wu           VdVjVk          @modify=Vd
+70998000 vmulwev.q.du           VdVjVk          @modify=Vd
+709a0000 vmulwod.h.bu           VdVjVk          @modify=Vd
+709a8000 vmulwod.w.hu           VdVjVk          @modify=Vd
+709b0000 vmulwod.d.wu           VdVjVk          @modify=Vd
+709b8000 vmulwod.q.du           VdVjVk          @modify=Vd
+70a00000 vmulwev.h.bu.b         VdVjVk          @modify=Vd
+70a08000 vmulwev.w.hu.h         VdVjVk          @modify=Vd
+70a10000 vmulwev.d.wu.w         VdVjVk          @modify=Vd
+70a18000 vmulwev.q.du.d         VdVjVk          @modify=Vd
+70a20000 vmulwod.h.bu.b         VdVjVk          @modify=Vd
+70a28000 vmulwod.w.hu.h         VdVjVk          @modify=Vd
+70a30000 vmulwod.d.wu.w         VdVjVk          @modify=Vd
+70a38000 vmulwod.q.du.d         VdVjVk          @modify=Vd
+70a80000 vmadd.b                VdVjVk          @modify=Vd
+70a88000 vmadd.h                VdVjVk          @modify=Vd
+70a90000 vmadd.w                VdVjVk          @modify=Vd
+70a98000 vmadd.d                VdVjVk          @modify=Vd
+70aa0000 vmsub.b                VdVjVk          @modify=Vd
+70aa8000 vmsub.h                VdVjVk          @modify=Vd
+70ab0000 vmsub.w                VdVjVk          @modify=Vd
+70ab8000 vmsub.d                VdVjVk          @modify=Vd
+70ac0000 vmaddwev.h.b           VdVjVk          @modify=Vd
+70ac8000 vmaddwev.w.h           VdVjVk          @modify=Vd
+70ad0000 vmaddwev.d.w           VdVjVk          @modify=Vd
+70ad8000 vmaddwev.q.d           VdVjVk          @modify=Vd
+70ae0000 vmaddwod.h.b           VdVjVk          @modify=Vd
+70ae8000 vmaddwod.w.h           VdVjVk          @modify=Vd
+70af0000 vmaddwod.d.w           VdVjVk          @modify=Vd
+70af8000 vmaddwod.q.d           VdVjVk          @modify=Vd
+70b40000 vmaddwev.h.bu          VdVjVk          @modify=Vd
+70b48000 vmaddwev.w.hu          VdVjVk          @modify=Vd
+70b50000 vmaddwev.d.wu          VdVjVk          @modify=Vd
+70b58000 vmaddwev.q.du          VdVjVk          @modify=Vd
+70b60000 vmaddwod.h.bu          VdVjVk          @modify=Vd
+70b68000 vmaddwod.w.hu          VdVjVk          @modify=Vd
+70b70000 vmaddwod.d.wu          VdVjVk          @modify=Vd
+70b78000 vmaddwod.q.du          VdVjVk          @modify=Vd
+70bc0000 vmaddwev.h.bu.b        VdVjVk          @modify=Vd
+70bc8000 vmaddwev.w.hu.h        VdVjVk          @modify=Vd
+70bd0000 vmaddwev.d.wu.w        VdVjVk          @modify=Vd
+70bd8000 vmaddwev.q.du.d        VdVjVk          @modify=Vd
+70be0000 vmaddwod.h.bu.b        VdVjVk          @modify=Vd
+70be8000 vmaddwod.w.hu.h        VdVjVk          @modify=Vd
+70bf0000 vmaddwod.d.wu.w        VdVjVk          @modify=Vd
+70bf8000 vmaddwod.q.du.d        VdVjVk          @modify=Vd
+70e00000 vdiv.b                 VdVjVk          @modify=Vd
+70e08000 vdiv.h                 VdVjVk          @modify=Vd
+70e10000 vdiv.w                 VdVjVk          @modify=Vd
+70e18000 vdiv.d                 VdVjVk          @modify=Vd
+70e20000 vmod.b                 VdVjVk          @modify=Vd
+70e28000 vmod.h                 VdVjVk          @modify=Vd
+70e30000 vmod.w                 VdVjVk          @modify=Vd
+70e38000 vmod.d                 VdVjVk          @modify=Vd
+70e40000 vdiv.bu                VdVjVk          @modify=Vd
+70e48000 vdiv.hu                VdVjVk          @modify=Vd
+70e50000 vdiv.wu                VdVjVk          @modify=Vd
+70e58000 vdiv.du                VdVjVk          @modify=Vd
+70e60000 vmod.bu                VdVjVk          @modify=Vd
+70e68000 vmod.hu                VdVjVk          @modify=Vd
+70e70000 vmod.wu                VdVjVk          @modify=Vd
+70e78000 vmod.du                VdVjVk          @modify=Vd
+70e80000 vsll.b                 VdVjVk          @qemu @modify=Vd
+70e88000 vsll.h                 VdVjVk          @qemu @modify=Vd
+70e90000 vsll.w                 VdVjVk          @qemu @modify=Vd
+70e98000 vsll.d                 VdVjVk          @qemu @modify=Vd
+70ea0000 vsrl.b                 VdVjVk          @qemu @modify=Vd
+70ea8000 vsrl.h                 VdVjVk          @qemu @modify=Vd
+70eb0000 vsrl.w                 VdVjVk          @qemu @modify=Vd
+70eb8000 vsrl.d                 VdVjVk          @qemu @modify=Vd
+70ec0000 vsra.b                 VdVjVk          @qemu @modify=Vd
+70ec8000 vsra.h                 VdVjVk          @qemu @modify=Vd
+70ed0000 vsra.w                 VdVjVk          @qemu @modify=Vd
+70ed8000 vsra.d                 VdVjVk          @qemu @modify=Vd
+70ee0000 vrotr.b                VdVjVk          @qemu @modify=Vd
+70ee8000 vrotr.h                VdVjVk          @qemu @modify=Vd
+70ef0000 vrotr.w                VdVjVk          @qemu @modify=Vd
+70ef8000 vrotr.d                VdVjVk          @qemu @modify=Vd
+70f00000 vsrlr.b                VdVjVk          @modify=Vd
+70f08000 vsrlr.h                VdVjVk          @modify=Vd
+70f10000 vsrlr.w                VdVjVk          @modify=Vd
+70f18000 vsrlr.d                VdVjVk          @modify=Vd
+70f20000 vsrar.b                VdVjVk          @modify=Vd
+70f28000 vsrar.h                VdVjVk          @modify=Vd
+70f30000 vsrar.w                VdVjVk          @modify=Vd
+70f38000 vsrar.d                VdVjVk          @modify=Vd
+70f48000 vsrln.b.h              VdVjVk          @modify=Vd
+70f50000 vsrln.h.w              VdVjVk          @modify=Vd
+70f58000 vsrln.w.d              VdVjVk          @modify=Vd
+70f68000 vsran.b.h              VdVjVk          @modify=Vd
+70f70000 vsran.h.w              VdVjVk          @modify=Vd
+70f78000 vsran.w.d              VdVjVk          @modify=Vd
+70f88000 vsrlrn.b.h             VdVjVk          @modify=Vd
+70f90000 vsrlrn.h.w             VdVjVk          @modify=Vd
+70f98000 vsrlrn.w.d             VdVjVk          @modify=Vd
+70fa8000 vsrarn.b.h             VdVjVk          @modify=Vd
+70fb0000 vsrarn.h.w             VdVjVk          @modify=Vd
+70fb8000 vsrarn.w.d             VdVjVk          @modify=Vd
+70fc8000 vssrln.b.h             VdVjVk          @modify=Vd
+70fd0000 vssrln.h.w             VdVjVk          @modify=Vd
+70fd8000 vssrln.w.d             VdVjVk          @modify=Vd
+70fe8000 vssran.b.h             VdVjVk          @modify=Vd
+70ff0000 vssran.h.w             VdVjVk          @modify=Vd
+70ff8000 vssran.w.d             VdVjVk          @modify=Vd
+71008000 vssrlrn.b.h            VdVjVk          @modify=Vd
+71010000 vssrlrn.h.w            VdVjVk          @modify=Vd
+71018000 vssrlrn.w.d            VdVjVk          @modify=Vd
+71028000 vssrarn.b.h            VdVjVk          @modify=Vd
+71030000 vssrarn.h.w            VdVjVk          @modify=Vd
+71038000 vssrarn.w.d            VdVjVk          @modify=Vd
+71048000 vssrln.bu.h            VdVjVk          @modify=Vd
+71050000 vssrln.hu.w            VdVjVk          @modify=Vd
+71058000 vssrln.wu.d            VdVjVk          @modify=Vd
+71068000 vssran.bu.h            VdVjVk          @modify=Vd
+71070000 vssran.hu.w            VdVjVk          @modify=Vd
+71078000 vssran.wu.d            VdVjVk          @modify=Vd
+71088000 vssrlrn.bu.h           VdVjVk          @modify=Vd
+71090000 vssrlrn.hu.w           VdVjVk          @modify=Vd
+71098000 vssrlrn.wu.d           VdVjVk          @modify=Vd
+710a8000 vssrarn.bu.h           VdVjVk          @modify=Vd
+710b0000 vssrarn.hu.w           VdVjVk          @modify=Vd
+710b8000 vssrarn.wu.d           VdVjVk          @modify=Vd
+710c0000 vbitclr.b              VdVjVk          @modify=Vd
+710c8000 vbitclr.h              VdVjVk          @modify=Vd
+710d0000 vbitclr.w              VdVjVk          @modify=Vd
+710d8000 vbitclr.d              VdVjVk          @modify=Vd
+710e0000 vbitset.b              VdVjVk          @modify=Vd
+710e8000 vbitset.h              VdVjVk          @modify=Vd
+710f0000 vbitset.w              VdVjVk          @modify=Vd
+710f8000 vbitset.d              VdVjVk          @modify=Vd
+71100000 vbitrev.b              VdVjVk          @modify=Vd
+71108000 vbitrev.h              VdVjVk          @modify=Vd
+71110000 vbitrev.w              VdVjVk          @modify=Vd
+71118000 vbitrev.d              VdVjVk          @modify=Vd
+71160000 vpackev.b              VdVjVk          @modify=Vd
+71168000 vpackev.h              VdVjVk          @modify=Vd
+71170000 vpackev.w              VdVjVk          @modify=Vd
+71178000 vpackev.d              VdVjVk          @modify=Vd
+71180000 vpackod.b              VdVjVk          @modify=Vd
+71188000 vpackod.h              VdVjVk          @modify=Vd
+71190000 vpackod.w              VdVjVk          @modify=Vd
+71198000 vpackod.d              VdVjVk          @modify=Vd
+711a0000 vilvl.b                VdVjVk          @modify=Vd
+711a8000 vilvl.h                VdVjVk          @modify=Vd
+711b0000 vilvl.w                VdVjVk          @modify=Vd
+711b8000 vilvl.d                VdVjVk          @modify=Vd
+711c0000 vilvh.b                VdVjVk          @modify=Vd
+711c8000 vilvh.h                VdVjVk          @modify=Vd
+711d0000 vilvh.w                VdVjVk          @modify=Vd
+711d8000 vilvh.d                VdVjVk          @modify=Vd
+711e0000 vpickev.b              VdVjVk          @modify=Vd
+711e8000 vpickev.h              VdVjVk          @modify=Vd
+711f0000 vpickev.w              VdVjVk          @modify=Vd
+711f8000 vpickev.d              VdVjVk          @modify=Vd
+71200000 vpickod.b              VdVjVk          @modify=Vd
+71208000 vpickod.h              VdVjVk          @modify=Vd
+71210000 vpickod.w              VdVjVk          @modify=Vd
+71218000 vpickod.d              VdVjVk          @modify=Vd
+71220000 vreplve.b              VdVjK           @qemu @modify=Vd
+71228000 vreplve.h              VdVjK           @qemu @modify=Vd
+71230000 vreplve.w              VdVjK           @qemu @modify=Vd
+71238000 vreplve.d              VdVjK           @qemu @modify=Vd
+71260000 vand.v                 VdVjVk          @qemu @modify=Vd
+71268000 vor.v                  VdVjVk          @qemu @modify=Vd
+71270000 vxor.v                 VdVjVk          @qemu @modify=Vd
+71278000 vnor.v                 VdVjVk          @qemu @modify=Vd
+71280000 vandn.v                VdVjVk          @qemu @modify=Vd
+71288000 vorn.v                 VdVjVk          @qemu @modify=Vd
+712b0000 vfrstp.b               VdVjVk          @modify=Vd
+712b8000 vfrstp.h               VdVjVk          @modify=Vd
+712d0000 vadd.q                 VdVjVk          @modify=Vd
+712d8000 vsub.q                 VdVjVk          @modify=Vd
+712e0000 vsigncov.b             VdVjVk          @modify=Vd
+712e8000 vsigncov.h             VdVjVk          @modify=Vd
+712f0000 vsigncov.w             VdVjVk          @modify=Vd
+712f8000 vsigncov.d             VdVjVk          @modify=Vd
+71308000 vfadd.s                VdVjVk          @modify=Vd
+71310000 vfadd.d                VdVjVk          @modify=Vd
+71328000 vfsub.s                VdVjVk          @modify=Vd
+71330000 vfsub.d                VdVjVk          @modify=Vd
+71388000 vfmul.s                VdVjVk          @modify=Vd
+71390000 vfmul.d                VdVjVk          @modify=Vd
+713a8000 vfdiv.s                VdVjVk          @modify=Vd
+713b0000 vfdiv.d                VdVjVk          @modify=Vd
+713c8000 vfmax.s                VdVjVk          @modify=Vd
+713d0000 vfmax.d                VdVjVk          @modify=Vd
+713e8000 vfmin.s                VdVjVk          @modify=Vd
+713f0000 vfmin.d                VdVjVk          @modify=Vd
+71408000 vfmaxa.s               VdVjVk          @modify=Vd
+71410000 vfmaxa.d               VdVjVk          @modify=Vd
+71428000 vfmina.s               VdVjVk          @modify=Vd
+71430000 vfmina.d               VdVjVk          @modify=Vd
+71460000 vfcvt.h.s              VdVjVk          @modify=Vd
+71468000 vfcvt.s.d              VdVjVk          @modify=Vd
+71480000 vffint.s.l             VdVjVk          @modify=Vd
+71498000 vftint.w.d             VdVjVk          @modify=Vd
+714a0000 vftintrm.w.d           VdVjVk          @modify=Vd
+714a8000 vftintrp.w.d           VdVjVk          @modify=Vd
+714b0000 vftintrz.w.d           VdVjVk          @modify=Vd
+714b8000 vftintrne.w.d          VdVjVk          @modify=Vd
+717a8000 vshuf.h                VdVjVk          @modify=Vd
+717b0000 vshuf.w                VdVjVk          @modify=Vd
+717b8000 vshuf.d                VdVjVk          @modify=Vd
+72800000 vseqi.b                VdVjSk5         @qemu @modify=Vd
+72808000 vseqi.h                VdVjSk5         @qemu @modify=Vd
+72810000 vseqi.w                VdVjSk5         @qemu @modify=Vd
+72818000 vseqi.d                VdVjSk5         @qemu @modify=Vd
+72820000 vslei.b                VdVjSk5         @qemu @modify=Vd
+72828000 vslei.h                VdVjSk5         @qemu @modify=Vd
+72830000 vslei.w                VdVjSk5         @qemu @modify=Vd
+72838000 vslei.d                VdVjSk5         @qemu @modify=Vd
+72840000 vslei.bu               VdVjUk5         @qemu @modify=Vd
+72848000 vslei.hu               VdVjUk5         @qemu @modify=Vd
+72850000 vslei.wu               VdVjUk5         @qemu @modify=Vd
+72858000 vslei.du               VdVjUk5         @qemu @modify=Vd
+72860000 vslti.b                VdVjSk5         @qemu @modify=Vd
+72868000 vslti.h                VdVjSk5         @qemu @modify=Vd
+72870000 vslti.w                VdVjSk5         @qemu @modify=Vd
+72878000 vslti.d                VdVjSk5         @qemu @modify=Vd
+72880000 vslti.bu               VdVjUk5         @qemu @modify=Vd
+72888000 vslti.hu               VdVjUk5         @qemu @modify=Vd
+72890000 vslti.wu               VdVjUk5         @qemu @modify=Vd
+72898000 vslti.du               VdVjUk5         @qemu @modify=Vd
+728a0000 vaddi.bu               VdVjUk5         @qemu @modify=Vd
+728a8000 vaddi.hu               VdVjUk5         @qemu @modify=Vd
+728b0000 vaddi.wu               VdVjUk5         @qemu @modify=Vd
+728b8000 vaddi.du               VdVjUk5         @qemu @modify=Vd
+728c0000 vsubi.bu               VdVjUk5         @qemu @modify=Vd
+728c8000 vsubi.hu               VdVjUk5         @qemu @modify=Vd
+728d0000 vsubi.wu               VdVjUk5         @qemu @modify=Vd
+728d8000 vsubi.du               VdVjUk5         @qemu @modify=Vd
+728e0000 vbsll.v                VdVjUk5         @modify=Vd
+728e8000 vbsrl.v                VdVjUk5         @modify=Vd
+72900000 vmaxi.b                VdVjSk5         @qemu @modify=Vd
+72908000 vmaxi.h                VdVjSk5         @qemu @modify=Vd
+72910000 vmaxi.w                VdVjSk5         @qemu @modify=Vd
+72918000 vmaxi.d                VdVjSk5         @qemu @modify=Vd
+72920000 vmini.b                VdVjSk5         @qemu @modify=Vd
+72928000 vmini.h                VdVjSk5         @qemu @modify=Vd
+72930000 vmini.w                VdVjSk5         @qemu @modify=Vd
+72938000 vmini.d                VdVjSk5         @qemu @modify=Vd
+72940000 vmaxi.bu               VdVjUk5         @qemu @modify=Vd
+72948000 vmaxi.hu               VdVjUk5         @qemu @modify=Vd
+72950000 vmaxi.wu               VdVjUk5         @qemu @modify=Vd
+72958000 vmaxi.du               VdVjUk5         @qemu @modify=Vd
+72960000 vmini.bu               VdVjUk5         @qemu @modify=Vd
+72968000 vmini.hu               VdVjUk5         @qemu @modify=Vd
+72970000 vmini.wu               VdVjUk5         @qemu @modify=Vd
+72978000 vmini.du               VdVjUk5         @qemu @modify=Vd
+729a0000 vfrstpi.b              VdVjUk5         @modify=Vd
+729a8000 vfrstpi.h              VdVjUk5         @modify=Vd
+729b8000 vmepatmsk.v            VdUj5Uk5        @modify=Vd
+729c0000 vclo.b                 VdVj            @modify=Vd
+729c0400 vclo.h                 VdVj            @modify=Vd
+729c0800 vclo.w                 VdVj            @modify=Vd
+729c0c00 vclo.d                 VdVj            @modify=Vd
+729c1000 vclz.b                 VdVj            @modify=Vd
+729c1400 vclz.h                 VdVj            @modify=Vd
+729c1800 vclz.w                 VdVj            @modify=Vd
+729c1c00 vclz.d                 VdVj            @modify=Vd
+729c2000 vpcnt.b                VdVj            @modify=Vd
+729c2400 vpcnt.h                VdVj            @modify=Vd
+729c2800 vpcnt.w                VdVj            @modify=Vd
+729c2c00 vpcnt.d                VdVj            @modify=Vd
+729c3000 vneg.b                 VdVj            @qemu @modify=Vd
+729c3400 vneg.h                 VdVj            @qemu @modify=Vd
+729c3800 vneg.w                 VdVj            @qemu @modify=Vd
+729c3c00 vneg.d                 VdVj            @qemu @modify=Vd
+729c4000 vmskltz.b              VdVj            @modify=Vd
+729c4400 vmskltz.h              VdVj            @modify=Vd
+729c4800 vmskltz.w              VdVj            @modify=Vd
+729c4c00 vmskltz.d              VdVj            @modify=Vd
+729c5000 vmskgez.b              VdVj            @modify=Vd
+729c6000 vmsknz.b               VdVj            @modify=Vd
+729c9800 vseteqz.v              CdVj            @modify=Cd
+729c9c00 vsetnez.v              CdVj            @modify=Cd
+729ca000 vsetanyeqz.b           CdVj            @modify=Cd
+729ca400 vsetanyeqz.h           CdVj            @modify=Cd
+729ca800 vsetanyeqz.w           CdVj            @modify=Cd
+729cac00 vsetanyeqz.d           CdVj            @modify=Cd
+729cb000 vsetallnez.b           CdVj            @modify=Cd
+729cb400 vsetallnez.h           CdVj            @modify=Cd
+729cb800 vsetallnez.w           CdVj            @modify=Cd
+729cbc00 vsetallnez.d           CdVj            @modify=Cd
+729cc400 vflogb.s               VdVj            @modify=Vd
+729cc800 vflogb.d               VdVj            @modify=Vd
+729cd400 vfclass.s              VdVj            @modify=Vd
+729cd800 vfclass.d              VdVj            @modify=Vd
+729ce400 vfsqrt.s               VdVj            @modify=Vd
+729ce800 vfsqrt.d               VdVj            @modify=Vd
+729cf400 vfrecip.s              VdVj            @modify=Vd
+729cf800 vfrecip.d              VdVj            @modify=Vd
+729d0400 vfrsqrt.s              VdVj            @modify=Vd
+729d0800 vfrsqrt.d              VdVj            @modify=Vd
+729d1400 vfrecipe.s             VdVj            @rev=1p10 @modify=Vd
+729d1800 vfrecipe.d             VdVj            @rev=1p10 @modify=Vd
+729d2400 vfrsqrte.s             VdVj            @rev=1p10 @modify=Vd
+729d2800 vfrsqrte.d             VdVj            @rev=1p10 @modify=Vd
+729d3400 vfrint.s               VdVj            @modify=Vd
+729d3800 vfrint.d               VdVj            @modify=Vd
+729d4400 vfrintrm.s             VdVj            @modify=Vd
+729d4800 vfrintrm.d             VdVj            @modify=Vd
+729d5400 vfrintrp.s             VdVj            @modify=Vd
+729d5800 vfrintrp.d             VdVj            @modify=Vd
+729d6400 vfrintrz.s             VdVj            @modify=Vd
+729d6800 vfrintrz.d             VdVj            @modify=Vd
+729d7400 vfrintrne.s            VdVj            @modify=Vd
+729d7800 vfrintrne.d            VdVj            @modify=Vd
+729de800 vfcvtl.s.h             VdVj            @modify=Vd
+729dec00 vfcvth.s.h             VdVj            @modify=Vd
+729df000 vfcvtl.d.s             VdVj            @modify=Vd
+729df400 vfcvth.d.s             VdVj            @modify=Vd
+729e0000 vffint.s.w             VdVj            @modify=Vd
+729e0400 vffint.s.wu            VdVj            @modify=Vd
+729e0800 vffint.d.l             VdVj            @modify=Vd
+729e0c00 vffint.d.lu            VdVj            @modify=Vd
+729e1000 vffintl.d.w            VdVj            @modify=Vd
+729e1400 vffinth.d.w            VdVj            @modify=Vd
+729e3000 vftint.w.s             VdVj            @modify=Vd
+729e3400 vftint.l.d             VdVj            @modify=Vd
+729e3800 vftintrm.w.s           VdVj            @modify=Vd
+729e3c00 vftintrm.l.d           VdVj            @modify=Vd
+729e4000 vftintrp.w.s           VdVj            @modify=Vd
+729e4400 vftintrp.l.d           VdVj            @modify=Vd
+729e4800 vftintrz.w.s           VdVj            @modify=Vd
+729e4c00 vftintrz.l.d           VdVj            @modify=Vd
+729e5000 vftintrne.w.s          VdVj            @modify=Vd
+729e5400 vftintrne.l.d          VdVj            @modify=Vd
+729e5800 vftint.wu.s            VdVj            @modify=Vd
+729e5c00 vftint.lu.d            VdVj            @modify=Vd
+729e7000 vftintrz.wu.s          VdVj            @modify=Vd
+729e7400 vftintrz.lu.d          VdVj            @modify=Vd
+729e8000 vftintl.l.s            VdVj            @modify=Vd
+729e8400 vftinth.l.s            VdVj            @modify=Vd
+729e8800 vftintrml.l.s          VdVj            @modify=Vd
+729e8c00 vftintrmh.l.s          VdVj            @modify=Vd
+729e9000 vftintrpl.l.s          VdVj            @modify=Vd
+729e9400 vftintrph.l.s          VdVj            @modify=Vd
+729e9800 vftintrzl.l.s          VdVj            @modify=Vd
+729e9c00 vftintrzh.l.s          VdVj            @modify=Vd
+729ea000 vftintrnel.l.s         VdVj            @modify=Vd
+729ea400 vftintrneh.l.s         VdVj            @modify=Vd
+729ee000 vexth.h.b              VdVj            @modify=Vd
+729ee400 vexth.w.h              VdVj            @modify=Vd
+729ee800 vexth.d.w              VdVj            @modify=Vd
+729eec00 vexth.q.d              VdVj            @modify=Vd
+729ef000 vexth.hu.bu            VdVj            @modify=Vd
+729ef400 vexth.wu.hu            VdVj            @modify=Vd
+729ef800 vexth.du.wu            VdVj            @modify=Vd
+729efc00 vexth.qu.du            VdVj            @modify=Vd
+729f0000 vreplgr2vr.b           VdJ             @qemu @modify=Vd
+729f0400 vreplgr2vr.h           VdJ             @qemu @modify=Vd
+729f0800 vreplgr2vr.w           VdJ             @qemu @modify=Vd
+729f0c00 vreplgr2vr.d           VdJ             @qemu @modify=Vd
+72a02000 vrotri.b               VdVjUk3         @qemu @modify=Vd
+72a04000 vrotri.h               VdVjUk4         @qemu @modify=Vd
+72a08000 vrotri.w               VdVjUk5         @qemu @modify=Vd
+72a10000 vrotri.d               VdVjUk6         @qemu @modify=Vd
+72a42000 vsrlri.b               VdVjUk3         @modify=Vd
+72a44000 vsrlri.h               VdVjUk4         @modify=Vd
+72a48000 vsrlri.w               VdVjUk5         @modify=Vd
+72a50000 vsrlri.d               VdVjUk6         @modify=Vd
+72a82000 vsrari.b               VdVjUk3         @modify=Vd
+72a84000 vsrari.h               VdVjUk4         @modify=Vd
+72a88000 vsrari.w               VdVjUk5         @modify=Vd
+72a90000 vsrari.d               VdVjUk6         @modify=Vd
+72eb8000 vinsgr2vr.b            VdJUk4          @qemu @modify=Vd
+72ebc000 vinsgr2vr.h            VdJUk3          @qemu @modify=Vd
+72ebe000 vinsgr2vr.w            VdJUk2          @qemu @modify=Vd
+72ebf000 vinsgr2vr.d            VdJUk1          @qemu @modify=Vd
+72ef8000 vpickve2gr.b           DVjUk4          @qemu @modify=Vd
+72efc000 vpickve2gr.h           DVjUk3          @qemu @modify=Vd
+72efe000 vpickve2gr.w           DVjUk2          @qemu @modify=Vd
+72eff000 vpickve2gr.d           DVjUk1          @qemu @modify=Vd
+72f38000 vpickve2gr.bu          DVjUk4          @qemu @modify=Vd
+72f3c000 vpickve2gr.hu          DVjUk3          @qemu @modify=Vd
+72f3e000 vpickve2gr.wu          DVjUk2          @qemu @modify=Vd
+72f3f000 vpickve2gr.du          DVjUk1          @qemu @modify=Vd
+72f78000 vreplvei.b             VdVjUk4         @qemu @modify=Vd
+72f7c000 vreplvei.h             VdVjUk3         @qemu @modify=Vd
+72f7e000 vreplvei.w             VdVjUk2         @qemu @modify=Vd
+72f7f000 vreplvei.d             VdVjUk1         @qemu @modify=Vd
+73082000 vsllwil.h.b            VdVjUk3         @modify=Vd
+73084000 vsllwil.w.h            VdVjUk4         @modify=Vd
+73088000 vsllwil.d.w            VdVjUk5         @modify=Vd
+73090000 vextl.q.d              VdVj            @modify=Vd
+730c2000 vsllwil.hu.bu          VdVjUk3         @modify=Vd
+730c4000 vsllwil.wu.hu          VdVjUk4         @modify=Vd
+730c8000 vsllwil.du.wu          VdVjUk5         @modify=Vd
+730d0000 vextl.qu.du            VdVj            @modify=Vd
+73102000 vbitclri.b             VdVjUk3         @qemu @modify=Vd
+73104000 vbitclri.h             VdVjUk4         @qemu @modify=Vd
+73108000 vbitclri.w             VdVjUk5         @qemu @modify=Vd
+73110000 vbitclri.d             VdVjUk6         @qemu @modify=Vd
+73142000 vbitseti.b             VdVjUk3         @qemu @modify=Vd
+73144000 vbitseti.h             VdVjUk4         @qemu @modify=Vd
+73148000 vbitseti.w             VdVjUk5         @qemu @modify=Vd
+73150000 vbitseti.d             VdVjUk6         @qemu @modify=Vd
+73182000 vbitrevi.b             VdVjUk3         @qemu @modify=Vd
+73184000 vbitrevi.h             VdVjUk4         @qemu @modify=Vd
+73188000 vbitrevi.w             VdVjUk5         @qemu @modify=Vd
+73190000 vbitrevi.d             VdVjUk6         @qemu @modify=Vd
+73242000 vsat.b                 VdVjUk3         @modify=Vd
+73244000 vsat.h                 VdVjUk4         @modify=Vd
+73248000 vsat.w                 VdVjUk5         @modify=Vd
+73250000 vsat.d                 VdVjUk6         @modify=Vd
+73282000 vsat.bu                VdVjUk3         @modify=Vd
+73284000 vsat.hu                VdVjUk4         @modify=Vd
+73288000 vsat.wu                VdVjUk5         @modify=Vd
+73290000 vsat.du                VdVjUk6         @modify=Vd
+732c2000 vslli.b                VdVjUk3         @qemu @modify=Vd
+732c4000 vslli.h                VdVjUk4         @qemu @modify=Vd
+732c8000 vslli.w                VdVjUk5         @qemu @modify=Vd
+732d0000 vslli.d                VdVjUk6         @qemu @modify=Vd
+73302000 vsrli.b                VdVjUk3         @qemu @modify=Vd
+73304000 vsrli.h                VdVjUk4         @qemu @modify=Vd
+73308000 vsrli.w                VdVjUk5         @qemu @modify=Vd
+73310000 vsrli.d                VdVjUk6         @qemu @modify=Vd
+73342000 vsrai.b                VdVjUk3         @qemu @modify=Vd
+73344000 vsrai.h                VdVjUk4         @qemu @modify=Vd
+73348000 vsrai.w                VdVjUk5         @qemu @modify=Vd
+73350000 vsrai.d                VdVjUk6         @qemu @modify=Vd
+73404000 vsrlni.b.h             VdVjUk4         @modify=Vd
+73408000 vsrlni.h.w             VdVjUk5         @modify=Vd
+73410000 vsrlni.w.d             VdVjUk6         @modify=Vd
+73420000 vsrlni.d.q             VdVjUk7         @modify=Vd
+73444000 vsrlrni.b.h            VdVjUk4         @modify=Vd
+73448000 vsrlrni.h.w            VdVjUk5         @modify=Vd
+73450000 vsrlrni.w.d            VdVjUk6         @modify=Vd
+73460000 vsrlrni.d.q            VdVjUk7         @modify=Vd
+73484000 vssrlni.b.h            VdVjUk4         @modify=Vd
+73488000 vssrlni.h.w            VdVjUk5         @modify=Vd
+73490000 vssrlni.w.d            VdVjUk6         @modify=Vd
+734a0000 vssrlni.d.q            VdVjUk7         @modify=Vd
+734c4000 vssrlni.bu.h           VdVjUk4         @modify=Vd
+734c8000 vssrlni.hu.w           VdVjUk5         @modify=Vd
+734d0000 vssrlni.wu.d           VdVjUk6         @modify=Vd
+734e0000 vssrlni.du.q           VdVjUk7         @modify=Vd
+73504000 vssrlrni.b.h           VdVjUk4         @modify=Vd
+73508000 vssrlrni.h.w           VdVjUk5         @modify=Vd
+73510000 vssrlrni.w.d           VdVjUk6         @modify=Vd
+73520000 vssrlrni.d.q           VdVjUk7         @modify=Vd
+73544000 vssrlrni.bu.h          VdVjUk4         @modify=Vd
+73548000 vssrlrni.hu.w          VdVjUk5         @modify=Vd
+73550000 vssrlrni.wu.d          VdVjUk6         @modify=Vd
+73560000 vssrlrni.du.q          VdVjUk7         @modify=Vd
+73584000 vsrani.b.h             VdVjUk4         @modify=Vd
+73588000 vsrani.h.w             VdVjUk5         @modify=Vd
+73590000 vsrani.w.d             VdVjUk6         @modify=Vd
+735a0000 vsrani.d.q             VdVjUk7         @modify=Vd
+735c4000 vsrarni.b.h            VdVjUk4         @modify=Vd
+735c8000 vsrarni.h.w            VdVjUk5         @modify=Vd
+735d0000 vsrarni.w.d            VdVjUk6         @modify=Vd
+735e0000 vsrarni.d.q            VdVjUk7         @modify=Vd
+73604000 vssrani.b.h            VdVjUk4         @modify=Vd
+73608000 vssrani.h.w            VdVjUk5         @modify=Vd
+73610000 vssrani.w.d            VdVjUk6         @modify=Vd
+73620000 vssrani.d.q            VdVjUk7         @modify=Vd
+73644000 vssrani.bu.h           VdVjUk4         @modify=Vd
+73648000 vssrani.hu.w           VdVjUk5         @modify=Vd
+73650000 vssrani.wu.d           VdVjUk6         @modify=Vd
+73660000 vssrani.du.q           VdVjUk7         @modify=Vd
+73684000 vssrarni.b.h           VdVjUk4         @modify=Vd
+73688000 vssrarni.h.w           VdVjUk5         @modify=Vd
+73690000 vssrarni.w.d           VdVjUk6         @modify=Vd
+736a0000 vssrarni.d.q           VdVjUk7         @modify=Vd
+736c4000 vssrarni.bu.h          VdVjUk4         @modify=Vd
+736c8000 vssrarni.hu.w          VdVjUk5         @modify=Vd
+736d0000 vssrarni.wu.d          VdVjUk6         @modify=Vd
+736e0000 vssrarni.du.q          VdVjUk7         @modify=Vd
+73800000 vextrins.d             VdVjUk8         @modify=Vd
+73840000 vextrins.w             VdVjUk8         @modify=Vd
+73880000 vextrins.h             VdVjUk8         @modify=Vd
+738c0000 vextrins.b             VdVjUk8         @modify=Vd
+73900000 vshuf4i.b              VdVjUk8         @modify=Vd
+73940000 vshuf4i.h              VdVjUk8         @modify=Vd
+73980000 vshuf4i.w              VdVjUk8         @modify=Vd
+739c0000 vshuf4i.d              VdVjUk8         @modify=Vd
+73c40000 vbitseli.b             VdVjUk8         @qemu @modify=Vd
+73d00000 vandi.b                VdVjUk8         @qemu @modify=Vd
+73d40000 vori.b                 VdVjUk8         @qemu @modify=Vd
+73d80000 vxori.b                VdVjUk8         @qemu @modify=Vd
+73dc0000 vnori.b                VdVjUk8         @qemu @modify=Vd
+73e00000 vldi                   VdSj13          @qemu @modify=Vd
+73e40000 vpermi.w               VdVjUk8         @modify=Vd

--- a/lvz.txt
+++ b/lvz.txt
@@ -1,4 +1,4 @@
-05000000 gcsrxchg               DJUk14          @lvz
+05000000 gcsrxchg               DJUk14          @lvz @modify=D
 06482001 gtlbclr                EMPTY           @lvz
 06482401 gtlbflush              EMPTY           @lvz
 06482801 gtlbsrch               EMPTY           @lvz

--- a/scripts/go/common/emitter.go
+++ b/scripts/go/common/emitter.go
@@ -21,6 +21,7 @@ func (c *EmitterCtx) Finalize() []byte {
 		return c.buf.Bytes()
 	}
 
+	print(string(c.buf.Bytes()))
 	result, err := format.Source(c.buf.Bytes())
 	if err != nil {
 		panic(err)

--- a/scripts/go/geninsndata/main.go
+++ b/scripts/go/geninsndata/main.go
@@ -75,6 +75,7 @@ const (
 	slotK = 10
 	slotA = 15
 	slotM = 16
+	slotN = 18
 )
 
 func gatherDistinctSlotCombinations(fmts []*common.InsnFormat) []string {
@@ -120,6 +121,8 @@ func slotCombinationForFmt(f *common.InsnFormat) string {
 			sb.WriteRune('A')
 		case slotM:
 			sb.WriteRune('M')
+		case slotN:
+			sb.WriteRune('N')
 		default:
 			panic("should never happen")
 		}
@@ -140,6 +143,8 @@ func slotOffsetFromRune(s rune) int {
 		return slotA
 	case 'M', 'm':
 		return slotM
+	case 'N', 'n':
+		return slotN
 	default:
 		panic("should never happen")
 	}
@@ -290,6 +295,15 @@ func emitValidatorForFormat(ectx *common.EmitterCtx, f *common.InsnFormat) {
 		case common.ArgKindFCCReg:
 			ectx.Emit("wantFCCReg(insn.as, %s)", argParamName)
 
+		case common.ArgKindScratchReg:
+			ectx.Emit("wantLBTScratchReg(insn.as, %s)", argParamName)
+
+		case common.ArgKindVReg:
+			ectx.Emit("wantLSXReg(insn.as, %s)", argParamName)
+
+		case common.ArgKindXReg:
+			ectx.Emit("wantLASXReg(insn.as, %s)", argParamName)
+
 		case common.ArgKindSignedImm,
 			common.ArgKindUnsignedImm:
 			// want[Un]signedImm(argX, width)
@@ -388,6 +402,12 @@ func emitBigEncoderFn(ectx *common.EmitterCtx, fmts []*common.InsnFormat) {
 				ectx.Emit("regFP(%s)", fieldExpr)
 			case common.ArgKindFCCReg:
 				ectx.Emit("regFCC(%s)", fieldExpr)
+			case common.ArgKindScratchReg:
+				ectx.Emit("regLBTScratch(%s)", fieldExpr)
+			case common.ArgKindVReg:
+				ectx.Emit("regLSX(%s)", fieldExpr)
+			case common.ArgKindXReg:
+				ectx.Emit("regLASX(%s)", fieldExpr)
 			case common.ArgKindSignedImm, common.ArgKindUnsignedImm:
 				widthMask := (1 << a.TotalWidth()) - 1
 				ectx.Emit("uint32(%s) & 0x%x", fieldExpr, widthMask)


### PR DESCRIPTION
Add annotations for register slots that MAY be modified by an opcode.

This is useful for register allocator and optimizers. However we can't simply guess modified registers based on the format. For example, both `rdtimel.w` and `cpucfg` are `DJ`, but `rdtimel.w` modifies both rd and rj while `cpucfg` modifies only rd.